### PR TITLE
feat(global): 공통 예외처리 구현

### DIFF
--- a/src/main/java/com/zerobase/nsbackend/global/exceptionHandle/ErrorCode.java
+++ b/src/main/java/com/zerobase/nsbackend/global/exceptionHandle/ErrorCode.java
@@ -1,0 +1,26 @@
+package com.zerobase.nsbackend.global.exceptionHandle;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+  MEMBER_NOT_FOUND("10001", "회원을 찾지 못했습니다.");
+  private final String code;
+  private final String description;
+
+  private static final Map<String, ErrorCode> ERROR_CODE_MAP = new HashMap<>();
+
+  static {
+    for (ErrorCode errorCode : ErrorCode.values()) {
+      ERROR_CODE_MAP.put(errorCode.description, errorCode);
+    }
+  }
+
+  public static ErrorCode findCode(String description) {
+    return ERROR_CODE_MAP.get(description);
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/global/exceptionHandle/ErrorResponse.java
+++ b/src/main/java/com/zerobase/nsbackend/global/exceptionHandle/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.zerobase.nsbackend.global.exceptionHandle;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class ErrorResponse {
+  private final String errorCode;
+  private final String description;
+  private final LocalDateTime dateTime;
+  private final UUID logId;
+
+  public static ErrorResponse of(UUID logId, Exception exception) {
+    ErrorCode errorcode = ErrorCode.findCode(exception.getMessage());
+
+    return ErrorResponse.builder()
+        .errorCode(errorcode.getCode())
+        .description(errorcode.getDescription())
+        .dateTime(LocalDateTime.now())
+        .logId(logId)
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/global/exceptionHandle/GlobalExceptionHandler.java
+++ b/src/main/java/com/zerobase/nsbackend/global/exceptionHandle/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.zerobase.nsbackend.global.exceptionHandle;
+
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  private UUID generateLogId(Exception ex) {
+    return UUID.randomUUID();
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorResponse handleIllegalArgumentException(IllegalArgumentException ex) {
+    UUID uuid = generateLogId(ex);
+    log.info("## info : {}, {}", uuid, ex.getClass().getSimpleName(), ex);
+    return ErrorResponse.of(generateLogId(ex), ex);
+  }
+
+  @ExceptionHandler(Exception.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  public ErrorResponse handleIllegalArgumentException(Exception ex) {
+    UUID uuid = generateLogId(ex);
+    log.error("## error : {}, {}", uuid, ex.getClass().getSimpleName(), ex);
+    return ErrorResponse.of(generateLogId(ex), ex);
+  }
+}


### PR DESCRIPTION
resolved: #15

## AS-IS
- 공통 예외처리가 필요했습니다.
- 에러 코드를 반환해 주어야 했습니다.
- 개발 편의성을 위해, 로그에는 에러 코드가 아닌 에러 메세지를 표시하고, API 반환값에도 Code와 메세지가 같이 들어가는 것이 좋아 보였습니다.

<br/>

## key Changes ⭐️
- GlobalExceptionHandler 
   - RestControllerAdvice
   - 공통예외처리 
- ErrorResposne
   - 예외 반환값 템플릿
   - 에러코드와 에러 메세지 포함
-  ErrorCode
   - code(에러코드), description(에러 메세지)
   - findCode (에러 메시지로 에러 찾는 함수)추가
   
사용방법
1. ErrorCode enum에 에러 코드와 메세지를 추가합니다. <br/>
<img width="559" alt="image" src="https://github.com/my-neighborhood-solver/nsBackEnd/assets/78974381/52d84549-b4e4-4f19-8f6c-97a1768c5163"> <br/>

2. 예외 발생 상황에 표준 예외와 함께 ErrorCode의 desciption을 반환합니다. <br/>
<img width="652" alt="image" src="https://github.com/my-neighborhood-solver/nsBackEnd/assets/78974381/62650652-bb36-4811-883f-d1cb801a6245"> <br/>

3. RestControllerAdvice에서 에러 반환될때 에러코드를 찾아서 에러코드와 메세지가 같이 반환됩니다. <br/>


<br/>

## To Reviewers 🙏
- 멘토님이 말씀해 주신 에러 코드는 아래를 뜻하는 것 같습니다. (Http Status와 다른 직접 정의한 에러코드입니다.)
<img width="620" alt="image" src="https://github.com/my-neighborhood-solver/nsBackEnd/assets/78974381/6d5c6a6a-99c6-4f2e-852c-6c27918fc3de">

- ErrorCode enum에 에러 코드와 에러 메세지가 같이 존재합니다.
- 에러 메세지로 표준예외에 반환을 하면, ControllerAdvice에서 에러코드를 찾아서 (ErrorCode의 findCode) 반환합니다.
- 성능 향상을 위해 Map으로 enum 값을 담아 두었습니다.

<br/>
