### PR TITLE
feat(global): 에러 코드 기능 구분

### DIFF
--- a/src/main/java/com/zerobase/nsbackend/global/exceptionHandle/ErrorCode.java
+++ b/src/main/java/com/zerobase/nsbackend/global/exceptionHandle/ErrorCode.java
@@ -8,7 +8,32 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-  MEMBER_NOT_FOUND("10001", "회원을 찾지 못했습니다.");
+
+  /**
+   * 공통 에러 메세지
+   * 규칙 : 1000 ~ 19999
+   */
+  INTERNAL_SERVER_ERROR("1000", "일시적인 장애 입니다."),
+  /**
+   * 회원 도메인 에러 메세지
+   * 규칙 : 2000 ~ 2999
+   */
+  MEMBER_NOT_FOUND("2000", "회원을 찾지 못했습니다."),
+
+  /**
+   * 의뢰 도메인 에러 메세지
+   * 규칙 : 3000 ~ 3999
+   */
+  ERRAND_NOT_FOUND("3000", "의뢰를 찾지 못했습니다."),
+  /**
+   * 채팅 도메인 에러 메세지
+   * 규칙 : 4000 ~ 4999
+   */
+  CHATTING_NOT_FOUND("4000", "채팅을 찾지 못했습니다.");
+
+
+
+
   private final String code;
   private final String description;
 


### PR DESCRIPTION

related to: #15

## Motivations 🔥
- 에러 코드를 도메인 별로 구분해서 관리하고 싶었습니다.

<br/>

## key Changes ⭐️
- 에러 도메인 별 코드 구분
   - 공통 : 1000 번대
   - 회원 : 2000 번대
   - 의뢰 : 3000 번대
   - 채팅 : 4000 번대

<br/>

## To Reviewers 🙏
- 해당 코드 범위 내에서 자유롭게 구현해주시면 됩니다
- 문의 사항이나 건의 사항은 자유롭게 리뷰 주세요

<br/>
