### PR TITLE
의뢰 엔티티 && 의뢰 추가 기능

### DIFF
--- a/src/main/java/com/zerobase/nsbackend/errand/domain/Errand.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/Errand.java
@@ -1,0 +1,34 @@
+package com.zerobase.nsbackend.errand.domain;
+
+import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
+import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Errand {
+  @Id @GeneratedValue
+  private Long id;
+  @Column(length = 500)
+  private String title;
+  @Column(columnDefinition = "TEXT")
+  private String content;
+  private PayDivision payDivision;
+  private Integer pay;
+  private ErrandStatus status;
+  private Integer viewCount;
+  private LocalDateTime createdAt;
+}
+

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandController.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandController.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,7 +16,7 @@ public class ErrandController {
   private final ErrandService errandService;
 
   @PostMapping
-  public ResponseEntity<Void> createErrand(ErrandCreateRequest request) {
+  public ResponseEntity<Void> createErrand(@RequestBody ErrandCreateRequest request) {
     Errand errand = errandService.createErrand(request);
     return ResponseEntity.created(URI.create("/errands/" + errand.getId())).build();
   }

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandController.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandController.java
@@ -1,0 +1,22 @@
+package com.zerobase.nsbackend.errand.domain;
+
+import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/errands")
+@RestController
+public class ErrandController {
+  private final ErrandService errandService;
+
+  @PostMapping
+  public ResponseEntity<Void> createErrand(ErrandCreateRequest request) {
+    Errand errand = errandService.createErrand(request);
+    return ResponseEntity.created(URI.create("/errands/" + errand.getId())).build();
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
@@ -1,0 +1,29 @@
+package com.zerobase.nsbackend.errand.domain;
+
+import com.zerobase.nsbackend.errand.domain.repository.ErrandRepository;
+import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
+import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
+import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ErrandService {
+  private final ErrandRepository errandRepository;
+
+  public Errand createErrand(ErrandCreateRequest request) {
+    // TODO: 회원 유효성 체크 필요
+
+    return errandRepository.save(
+        Errand.builder()
+            .title(request.getTitle())
+            .content(request.getContent())
+            .payDivision(request.getPayDivision())
+            .pay(request.getPay())
+            .status(ErrandStatus.REQUEST)
+            .viewCount(0)
+            .build());
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
@@ -1,0 +1,8 @@
+package com.zerobase.nsbackend.errand.domain.repository;
+
+import com.zerobase.nsbackend.errand.domain.Errand;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ErrandRepository extends JpaRepository<Errand, Long> {
+
+}

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/vo/ErrandStatus.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/vo/ErrandStatus.java
@@ -1,0 +1,16 @@
+package com.zerobase.nsbackend.errand.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrandStatus {
+  REQUEST("REQUEST", "요청"),
+  PERFORMING("PERFORMING", "의뢰중"),
+  FINISH("FINISH", "완료"),
+  CANCEL("CANCEL", "취소");
+
+  private final String code;
+  private final String description;
+}

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/vo/PayDivision.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/vo/PayDivision.java
@@ -1,0 +1,15 @@
+package com.zerobase.nsbackend.errand.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PayDivision {
+
+  HOURLY("HOURLY", "시급"),
+  UNIT("UNIT", "단가");
+
+  private final String code;
+  private final String description;
+}

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandCreateRequest.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandCreateRequest.java
@@ -1,0 +1,17 @@
+package com.zerobase.nsbackend.errand.dto;
+
+import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ErrandCreateRequest {
+  private Long erranderId;
+  private String title;
+  private String content;
+  private PayDivision payDivision;
+  private Integer pay;
+}

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
@@ -1,0 +1,30 @@
+package com.zerobase.nsbackend.errand.dto;
+
+import com.zerobase.nsbackend.errand.domain.Errand;
+import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ErrandDto {
+  private Long id;
+  private String title;
+  private String content;
+  private PayDivision payDivision;
+  private Integer pay;
+  private LocalDateTime createdAt;
+
+  public static ErrandDto from(Errand errand) {
+    return ErrandDto.builder()
+        .id(errand.getId())
+        .title(errand.getTitle())
+        .content(errand.getContent())
+        .payDivision(errand.getPayDivision())
+        .pay(errand.getPay())
+        .build();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,13 @@ spring:
     url: jdbc:mysql://localhost:3376/neighborSolver
     username: root
     password: 12
+
+  jpa:
+    show-sql: true
+    database: mysql
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+    hibernate:
+      ddl-auto: create-drop

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
@@ -1,0 +1,44 @@
+package com.zerobase.nsbackend.integrationTest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
+import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@DisplayName("의뢰 통합 테스트")
+public class ErrandIntegrationTest extends IntegrationTest {
+
+  @DisplayName("의뢰 생성에 성공합니다.")
+  @Test
+  public void createErrand_success() throws Exception {
+    // given
+    ErrandCreateRequest createRequest = ErrandCreateRequest.builder()
+        //.erranderId() //TODO: 회원 구현 되면 아이디 넣을 것
+        .title("testTitle")
+        .content("testContent")
+        .payDivision(PayDivision.HOURLY)
+        .pay(10000)
+        .build();
+
+    // when
+    ResultActions resultActions = mvc.perform(
+            post("/errands")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(createRequest))
+                .accept(MediaType.APPLICATION_JSON))
+        .andDo(print());
+
+    // then
+    resultActions
+        .andExpect(status().isCreated())
+        .andExpect(header().string("Location", CoreMatchers.startsWith("/errands/")));
+  }
+}

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/IntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/IntegrationTest.java
@@ -1,0 +1,34 @@
+package com.zerobase.nsbackend.integrationTest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 통합테스트 베이스 클래스입니다.
+ * 통합테스트 시 상속 받아 사용합니다.
+ */
+@Disabled
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@SpringBootTest
+public class IntegrationTest {
+  @Autowired
+  protected MockMvc mvc;
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  protected String asJsonString(final Object obj) {
+    try {
+      return new ObjectMapper().writeValueAsString(obj);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
related to: https://github.com/my-neighborhood-solver/nsBackEnd/issues/7

Motivations 🔥
의뢰 테이블을 참고하여 의뢰 엔티티를 구현하기 [ERD](https://www.erdcloud.com/d/AeNfwyMHsLWzFcojt)
의뢰 생성 기능 넣기
공통 통합테스트 구현 + 의뢰 통합 테스트 클래스 구현

key Changes ⭐️
Errand : 의뢰 Entity
Controller, Service : 의뢰 생성 기능 추가
IntegrationTest : 공통 통합 테스트 클래스
ErrandIntegrationTest : 의뢰 통합테스트

To Reviewers 🙏
테이블과 엔티티가 매핑이 잘 되었는지 확인해 주세요
통합 테스트에 관해 궁금한 점이 있으면 질문 주세요