### PR TITLE
사진 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // aws
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/zerobase/nsbackend/global/customException/FileUploadException.java
+++ b/src/main/java/com/zerobase/nsbackend/global/customException/FileUploadException.java
@@ -1,0 +1,14 @@
+package com.zerobase.nsbackend.global.customException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FileUploadException extends RuntimeException {
+  public FileUploadException(String message) {
+    super(message);
+  }
+
+  public FileUploadException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/global/exceptionHandle/ErrorCode.java
+++ b/src/main/java/com/zerobase/nsbackend/global/exceptionHandle/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
    * 규칙 : 1000 ~ 19999
    */
   INTERNAL_SERVER_ERROR("1000", "일시적인 장애 입니다."),
+  FAIL_TO_UPLOAD_FILE("1001", "파일 업로드에 실패했습니다."),
   /**
    * 회원 도메인 에러 메세지
    * 규칙 : 2000 ~ 2999

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/AWSStorageConfig.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/AWSStorageConfig.java
@@ -1,0 +1,29 @@
+package com.zerobase.nsbackend.global.fileUpload;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AWSStorageConfig {
+  @Value("${cloud.aws.credentials.access-key}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.secret-key}")
+  private String accessSecret;
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AmazonS3 s3Client() {
+    AWSCredentials credentials = new BasicAWSCredentials(accessKey, accessSecret);
+    return AmazonS3ClientBuilder.standard()
+        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+        .withRegion(region).build();
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/FileController.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/FileController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,9 +26,9 @@ public class FileController {
   }
 
   @PostMapping("/images")
-  public ResponseEntity<Void> uploadImage(@RequestParam("file") MultipartFile file) {
+  public ResponseEntity<UploadFile> uploadImage(@RequestParam("file") MultipartFile file) {
     UploadFile uploadFile = storeFile.storeFile(file);
-    return ResponseEntity.created(URI.create("/images/" + uploadFile.getStoreFileName())).build();
+    return ResponseEntity.status(HttpStatus.CREATED).body(uploadFile);
   }
 
   @DeleteMapping("/images/{filename}")

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/FileController.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/FileController.java
@@ -1,0 +1,38 @@
+package com.zerobase.nsbackend.global.fileUpload;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class FileController {
+  private final StoreFile storeFile;
+
+  @GetMapping("/images/{filename}")
+  public ResponseEntity<Resource> downloadImage(@PathVariable String filename) {
+    return ResponseEntity.ok(storeFile.getFile(filename));
+  }
+
+  @PostMapping("/images")
+  public ResponseEntity<Void> uploadImage(@RequestParam("file") MultipartFile file) {
+    UploadFile uploadFile = storeFile.storeFile(file);
+    return ResponseEntity.created(URI.create("/images/" + uploadFile.getStoreFileName())).build();
+  }
+
+  @DeleteMapping("/images/{filename}")
+  public ResponseEntity<Void> deleteImage(@PathVariable String filename) {
+    storeFile.deleteFile(filename);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/StoreFile.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/StoreFile.java
@@ -1,0 +1,50 @@
+package com.zerobase.nsbackend.global.fileUpload;
+
+import java.util.UUID;
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StoreFile {
+
+  /**
+   * 해당 파일을 반환합니다.
+   * @param filename
+   * @return
+   */
+  Resource getFile(String filename);
+
+  /**
+   * 하나의 파일을 업로드 합니다.
+   * @param multipartFile
+   * @return
+   */
+  UploadFile storeFile(MultipartFile multipartFile);
+
+  /**
+   * 파일을 삭제합니다.
+   * @param filename
+   */
+  void deleteFile(String filename);
+
+  /**
+   * 저장할 파일 이름을 생성합니다.
+   * UUID 에 기존 파일의 확장자를 붙혀서 만듭니다.
+   * @param originalFilename
+   * @return
+   */
+  default String createStoreFileName(String originalFilename) {
+    String ext = extractExt(originalFilename);
+    String uuid = UUID.randomUUID().toString();
+    return uuid + "." + ext;
+  }
+
+  /**
+   * 파일의 확장자를 반환합니다.
+   * @param originalFilename
+   * @return
+   */
+  default String extractExt(String originalFilename) {
+    int pos = originalFilename.lastIndexOf(".");
+    return originalFilename.substring(pos + 1);
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/StoreFileToAWS.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/StoreFileToAWS.java
@@ -1,0 +1,58 @@
+package com.zerobase.nsbackend.global.fileUpload;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.zerobase.nsbackend.global.customException.FileUploadException;
+import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class StoreFileToAWS implements StoreFile {
+
+  @Value("${application.bucket.name}")
+  private String bucketName;
+
+  private final AmazonS3 s3Client;
+
+  @Override
+  public Resource getFile(String filename) {
+    S3Object s3Object = s3Client.getObject(bucketName, filename);
+    S3ObjectInputStream inputStream = s3Object.getObjectContent();
+    return new InputStreamResource(inputStream);
+  }
+
+  @Override
+  public UploadFile storeFile(MultipartFile multipartFile) {
+    log.info("### bucketName : " + bucketName);
+
+    String storeFileName = createStoreFileName(multipartFile.getOriginalFilename());
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentType(multipartFile.getContentType());
+
+    try (InputStream inputStream = multipartFile.getInputStream()) {
+      s3Client.putObject(new PutObjectRequest(bucketName, storeFileName, inputStream, objectMetadata));
+    } catch (IOException exception) {
+      throw new FileUploadException(ErrorCode.FAIL_TO_UPLOAD_FILE.getDescription(), exception);
+    }
+
+    return UploadFile.of(multipartFile.getOriginalFilename(), storeFileName);
+  }
+
+  @Override
+  public void deleteFile(String filename) {
+    s3Client.deleteObject(bucketName, filename);
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/UploadFile.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/UploadFile.java
@@ -1,0 +1,18 @@
+package com.zerobase.nsbackend.global.fileUpload;
+
+import lombok.Getter;
+
+@Getter
+public class UploadFile {
+  private String uploadFileName;
+  private String storeFileName;
+
+  public UploadFile(String uploadFileName, String storeFileName) {
+    this.uploadFileName = uploadFileName;
+    this.storeFileName = storeFileName;
+  }
+
+  public static UploadFile of(String uploadFileName, String storeFileName) {
+    return new UploadFile(uploadFileName, storeFileName);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,17 @@ spring:
         show_sql: true
     hibernate:
       ddl-auto: create-drop
+
+cloud:
+  aws:
+    credentials:
+      accessKey: AKIA2XCLNRPKPE447634
+      secretKey: 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
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
+application:
+  bucket:
+    name: my-neighbor-solver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,8 +18,8 @@ spring:
 cloud:
   aws:
     credentials:
-      accessKey: AKIA2XCLNRPKPE447634
-      secretKey: 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
+      accessKey:
+      secretKey:
     region:
       static: ap-northeast-2
     stack:

--- a/src/test/java/com/zerobase/nsbackend/global/fileUpload/FileUploadTest.java
+++ b/src/test/java/com/zerobase/nsbackend/global/fileUpload/FileUploadTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.zerobase.nsbackend.integrationTest.IntegrationTest;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -50,11 +51,10 @@ class FileUploadTest extends IntegrationTest {
         "Hello, World!".getBytes()
     );
     ResultActions createAction = mvc.perform(multipart("/images").file(file));
-    String newFileUri = createAction.andReturn().getResponse().getHeader("Location");
-    String filename = newFileUri.replace("/images/", "");
+    String newFileName = getNewFileName(createAction);
 
     // when
-    ResultActions resultActions = mvc.perform(get("/images/{filename}", filename))
+    ResultActions resultActions = mvc.perform(get("/images/{filename}", newFileName))
         .andDo(print());
 
     // then
@@ -65,13 +65,23 @@ class FileUploadTest extends IntegrationTest {
   }
 
   /**
+   * 저장된 파일 이름을 반환합니다.
+   * @param resultActions
+   * @return
+   * @throws Exception
+   */
+  private String getNewFileName(ResultActions resultActions) throws Exception {
+    String bodyString = resultActions.andReturn().getResponse().getContentAsString();
+    return objectMapper.readValue(bodyString, UploadFile.class).getStoreFileName();
+  }
+
+  /**
    * 테스트로 생성된 데이터를 삭제합니다.
    * @param resultActions
    * @throws Exception
    */
   private void removeFileAfterTest(ResultActions resultActions) throws Exception {
-    String newFileUri = resultActions.andReturn().getResponse().getHeader("Location");
-    String filename = newFileUri.replace("/images/", "");
-    mvc.perform(delete("/images/{filename}", filename));
+    String newFileName = getNewFileName(resultActions);
+    mvc.perform(delete("/images/{filename}", newFileName));
   }
 }

--- a/src/test/java/com/zerobase/nsbackend/global/fileUpload/FileUploadTest.java
+++ b/src/test/java/com/zerobase/nsbackend/global/fileUpload/FileUploadTest.java
@@ -1,0 +1,77 @@
+package com.zerobase.nsbackend.global.fileUpload;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.zerobase.nsbackend.integrationTest.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.ResultActions;
+
+class FileUploadTest extends IntegrationTest {
+  @Test
+  @DisplayName("파일 업르드 테스트")
+  public void whenFileUploaded_thenVerifyStatus()
+      throws Exception {
+    // given
+    MockMultipartFile file
+        = new MockMultipartFile(
+        "file",
+        "hello.txt",
+        MediaType.TEXT_PLAIN_VALUE,
+        "Hello, World!".getBytes()
+    );
+
+    // when
+    ResultActions resultActions = mvc.perform(multipart("/images").file(file))
+        .andDo(print());
+
+    // then
+    resultActions.andExpect(status().isCreated());
+
+    // 테스트로 생성된 데이터 삭제
+    removeFileAfterTest(resultActions);
+  }
+
+  @Test
+  @DisplayName("파일 조회 테스트")
+  void getFile_success() throws Exception {
+    // given
+    MockMultipartFile file
+        = new MockMultipartFile(
+        "file",
+        "hello.txt",
+        MediaType.TEXT_PLAIN_VALUE,
+        "Hello, World!".getBytes()
+    );
+    ResultActions createAction = mvc.perform(multipart("/images").file(file));
+    String newFileUri = createAction.andReturn().getResponse().getHeader("Location");
+    String filename = newFileUri.replace("/images/", "");
+
+    // when
+    ResultActions resultActions = mvc.perform(get("/images/{filename}", filename))
+        .andDo(print());
+
+    // then
+    resultActions.andExpect(status().isOk());
+
+    // 테스트 데이터 삭제
+    removeFileAfterTest(createAction);
+  }
+
+  /**
+   * 테스트로 생성된 데이터를 삭제합니다.
+   * @param resultActions
+   * @throws Exception
+   */
+  private void removeFileAfterTest(ResultActions resultActions) throws Exception {
+    String newFileUri = resultActions.andReturn().getResponse().getHeader("Location");
+    String filename = newFileUri.replace("/images/", "");
+    mvc.perform(delete("/images/{filename}", filename));
+  }
+}


### PR DESCRIPTION
## Motivations 🔥
- 회원 프로필 사진과 의뢰 사진을 업로드 하기 위한 공통 사진 업로드 기능을 구현하고 싶었습니다.

<br/>

## key Changes ⭐️
- 파일 업로드 구현 위치 - global/fileUpload
<br/>

- AWS 의존성과 설정 추가
   - `spring-cloud-starter-aws:2.2.6.RELEASE`
   - `AWS` `IAM`의 `secret key`, `access key`
   - `S3 bucket name`
<br/>

- 파일 조회, 추가, 삭제 기능 추가
   - 조회 : `GET` `/images/{filename}`
   - 추가 : `POST` `/images` (`multipartfile`)
   - 삭제 : `DELETE` `/images/{filename}``

구현 상세 내용
- 파일 이름은 UUID로 랜덤값을 생성합니다.
- StoreFile를 인터페이스를 구현하여 StoreFileToAws 구현하였습니다.
- MockMvc를 이용하여 테스트를 구현하였습니다.
<br/>

