### PR TITLE
의뢰 생성 시, 의뢰 사진 업르드 기능 추가

### DIFF
--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
@@ -3,6 +3,7 @@ package com.zerobase.nsbackend.errand.domain;
 import static com.zerobase.nsbackend.global.exceptionHandle.ErrorCode.DONT_HAVE_AUTHORITY_TO_DELETE;
 import static com.zerobase.nsbackend.global.exceptionHandle.ErrorCode.DONT_HAVE_AUTHORITY_TO_EDIT;
 
+import com.zerobase.nsbackend.errand.domain.entity.Errand;
 import com.zerobase.nsbackend.errand.domain.repository.ErrandRepository;
 import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
 import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
@@ -13,7 +14,6 @@ import com.zerobase.nsbackend.member.domain.Member;
 import com.zerobase.nsbackend.member.repository.MemberRepository;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
@@ -4,18 +4,24 @@ import static com.zerobase.nsbackend.global.exceptionHandle.ErrorCode.DONT_HAVE_
 import static com.zerobase.nsbackend.global.exceptionHandle.ErrorCode.DONT_HAVE_AUTHORITY_TO_EDIT;
 
 import com.zerobase.nsbackend.errand.domain.entity.Errand;
+import com.zerobase.nsbackend.errand.domain.entity.ErrandImage;
 import com.zerobase.nsbackend.errand.domain.repository.ErrandRepository;
 import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
 import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
 import com.zerobase.nsbackend.errand.dto.ErrandUpdateRequest;
 import com.zerobase.nsbackend.global.auth.AuthManager;
 import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
+import com.zerobase.nsbackend.global.fileUpload.StoreFile;
+import com.zerobase.nsbackend.global.fileUpload.UploadFile;
 import com.zerobase.nsbackend.member.domain.Member;
 import com.zerobase.nsbackend.member.repository.MemberRepository;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
@@ -23,16 +29,23 @@ public class ErrandService {
   private final MemberRepository memberRepository;
   private final ErrandRepository errandRepository;
   private final AuthManager authManager;
+  private final StoreFile storeFile;
 
   @Transactional
-  public Errand createErrand(ErrandCreateRequest request) {
+  public Errand createErrand(ErrandCreateRequest request, List<MultipartFile> imageRequest) {
     Member member = getMemberFromAuth();
+
+    // 아미지 업로드
+    List<UploadFile> uploadFiles = storeFile.storeFiles(imageRequest);
+    List<ErrandImage> images = uploadFiles.stream().map(UploadFile::toErrandImage)
+        .collect(Collectors.toList());
 
     return errandRepository.save(
         Errand.builder()
             .errander(member)
             .title(request.getTitle())
             .content(request.getContent())
+            .images(images)
             .payDivision(request.getPayDivision())
             .pay(request.getPay())
             .status(ErrandStatus.REQUEST)

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
@@ -4,6 +4,7 @@ import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
 import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
 import com.zerobase.nsbackend.global.BaseTimeEntity;
 import com.zerobase.nsbackend.member.domain.Member;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -12,6 +13,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,6 +35,8 @@ public class Errand extends BaseTimeEntity {
   private String title;
   @Column(columnDefinition = "TEXT")
   private String content;
+  @OneToMany(mappedBy = "errand")
+  private List<ErrandImage> images;
   @Enumerated(EnumType.STRING)
   private PayDivision payDivision;
   private Integer pay;

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
@@ -4,7 +4,9 @@ import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
 import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
 import com.zerobase.nsbackend.global.BaseTimeEntity;
 import com.zerobase.nsbackend.member.domain.Member;
+import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -12,6 +14,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.AccessLevel;
@@ -22,8 +25,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Errand extends BaseTimeEntity {
   @Id
@@ -35,8 +38,10 @@ public class Errand extends BaseTimeEntity {
   private String title;
   @Column(columnDefinition = "TEXT")
   private String content;
-  @OneToMany(mappedBy = "errand")
-  private List<ErrandImage> images;
+  @Builder.Default
+  @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+  @JoinColumn(name = "ERRAND_ID")
+  private List<ErrandImage> images = new ArrayList<>();
   @Enumerated(EnumType.STRING)
   private PayDivision payDivision;
   private Integer pay;

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
@@ -1,4 +1,4 @@
-package com.zerobase.nsbackend.errand.domain;
+package com.zerobase.nsbackend.errand.domain.entity;
 
 import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
 import com.zerobase.nsbackend.errand.domain.vo.PayDivision;

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/ErrandImage.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/ErrandImage.java
@@ -1,0 +1,39 @@
+package com.zerobase.nsbackend.errand.domain.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ErrandImage {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @ManyToOne
+  private Errand errand;
+  private String imageUrl;
+
+  @Builder
+  public ErrandImage(Errand errand, String imageUrl) {
+    changeErrand(errand);
+    this.imageUrl = imageUrl;
+  }
+
+  /**
+   * 연관관계 편의 메서드
+   */
+  public void changeErrand(Errand errand) {
+    if (this.errand != null) {
+      this.errand.getImages().remove(this);
+    }
+    this.errand = errand;
+    errand.getImages().add(this);
+  }
+
+}

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/ErrandImage.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/ErrandImage.java
@@ -4,9 +4,9 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,24 +16,19 @@ public class ErrandImage {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
   @ManyToOne
+  @JoinColumn(name = "ERRAND_ID")
   private Errand errand;
   private String imageUrl;
 
-  @Builder
-  public ErrandImage(Errand errand, String imageUrl) {
-    changeErrand(errand);
+  private ErrandImage(String imageUrl) {
     this.imageUrl = imageUrl;
   }
 
-  /**
-   * 연관관계 편의 메서드
-   */
-  public void changeErrand(Errand errand) {
-    if (this.errand != null) {
-      this.errand.getImages().remove(this);
-    }
-    this.errand = errand;
-    errand.getImages().add(this);
+  public static ErrandImage of(String imageUrl) {
+    return new ErrandImage(imageUrl);
   }
 
+  public String getImageUrl() {
+    return imageUrl;
+  }
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
@@ -1,6 +1,6 @@
 package com.zerobase.nsbackend.errand.domain.repository;
 
-import com.zerobase.nsbackend.errand.domain.Errand;
+import com.zerobase.nsbackend.errand.domain.entity.Errand;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ErrandRepository extends JpaRepository<Errand, Long> {

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandCreateRequest.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandCreateRequest.java
@@ -4,7 +4,11 @@ import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
+@NoArgsConstructor
 @Getter
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
@@ -1,6 +1,6 @@
 package com.zerobase.nsbackend.errand.dto;
 
-import com.zerobase.nsbackend.errand.domain.Errand;
+import com.zerobase.nsbackend.errand.domain.entity.Errand;
 import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
@@ -6,8 +6,10 @@ import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandDto;
 import com.zerobase.nsbackend.errand.dto.ErrandUpdateRequest;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,7 +17,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
 @PreAuthorize("hasRole('USER')")
 @RequiredArgsConstructor
 @RequestMapping("/errands")
@@ -25,8 +30,9 @@ public class ErrandController {
   private final ErrandService errandService;
 
   @PostMapping
-  public ResponseEntity<Void> createErrand(@RequestBody ErrandCreateRequest request) {
-    Errand errand = errandService.createErrand(request);
+  public ResponseEntity<Void> createErrand(@RequestPart("images") @Nullable List<MultipartFile> images,
+      @RequestPart("errand") ErrandCreateRequest request) {
+    Errand errand = errandService.createErrand(request, images);
     return ResponseEntity.created(URI.create("/errands/" + errand.getId())).build();
   }
 

--- a/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
@@ -1,6 +1,6 @@
 package com.zerobase.nsbackend.errand.web;
 
-import com.zerobase.nsbackend.errand.domain.Errand;
+import com.zerobase.nsbackend.errand.domain.entity.Errand;
 import com.zerobase.nsbackend.errand.domain.ErrandService;
 import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandDto;

--- a/src/main/java/com/zerobase/nsbackend/global/GlobalAppConfig.java
+++ b/src/main/java/com/zerobase/nsbackend/global/GlobalAppConfig.java
@@ -1,0 +1,17 @@
+package com.zerobase.nsbackend.global;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GlobalAppConfig {
+  @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY); // 팔드접근
+    return objectMapper;
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/global/GlobalAppConfig.java
+++ b/src/main/java/com/zerobase/nsbackend/global/GlobalAppConfig.java
@@ -8,10 +8,10 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class GlobalAppConfig {
-  @Bean
-  public ObjectMapper objectMapper() {
-    ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY); // 팔드접근
-    return objectMapper;
-  }
+//  @Bean
+//  public ObjectMapper objectMapper() {
+//    ObjectMapper objectMapper = new ObjectMapper();
+//    objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY); // 팔드접근
+//    return objectMapper;
+//  }
 }

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/FileController.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/FileController.java
@@ -1,11 +1,11 @@
 package com.zerobase.nsbackend.global.fileUpload;
 
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@PreAuthorize("hasRole('USER')")
 @Slf4j
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/StoreFile.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/StoreFile.java
@@ -1,6 +1,5 @@
 package com.zerobase.nsbackend.global.fileUpload;
 
-import java.util.UUID;
 import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,26 +24,4 @@ public interface StoreFile {
    * @param filename
    */
   void deleteFile(String filename);
-
-  /**
-   * 저장할 파일 이름을 생성합니다.
-   * UUID 에 기존 파일의 확장자를 붙혀서 만듭니다.
-   * @param originalFilename
-   * @return
-   */
-  default String createStoreFileName(String originalFilename) {
-    String ext = extractExt(originalFilename);
-    String uuid = UUID.randomUUID().toString();
-    return uuid + "." + ext;
-  }
-
-  /**
-   * 파일의 확장자를 반환합니다.
-   * @param originalFilename
-   * @return
-   */
-  default String extractExt(String originalFilename) {
-    int pos = originalFilename.lastIndexOf(".");
-    return originalFilename.substring(pos + 1);
-  }
 }

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/StoreFile.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/StoreFile.java
@@ -1,5 +1,6 @@
 package com.zerobase.nsbackend.global.fileUpload;
 
+import java.util.List;
 import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,6 +19,13 @@ public interface StoreFile {
    * @return
    */
   UploadFile storeFile(MultipartFile multipartFile);
+
+  /**
+   * 파일 여러개를 업로드 합니다.
+   * @param multipartFiles
+   * @return
+   */
+  List<UploadFile> storeFiles(List<MultipartFile> multipartFiles);
 
   /**
    * 파일을 삭제합니다.

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/StoreFileToAWS.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/StoreFileToAWS.java
@@ -9,6 +9,8 @@ import com.zerobase.nsbackend.global.customException.FileUploadException;
 import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,8 +49,6 @@ public class StoreFileToAWS implements StoreFile {
    */
   @Override
   public UploadFile storeFile(MultipartFile multipartFile) {
-    log.info("### bucketName : " + bucketName);
-
     String storeFileName = createStoreFileName(multipartFile.getOriginalFilename());
     ObjectMetadata objectMetadata = new ObjectMetadata();
     objectMetadata.setContentType(multipartFile.getContentType());
@@ -60,6 +60,19 @@ public class StoreFileToAWS implements StoreFile {
     }
 
     return UploadFile.of(multipartFile.getOriginalFilename(), storeFileName);
+  }
+
+  @Override
+  public List<UploadFile> storeFiles(List<MultipartFile> multipartFiles) {
+    if (multipartFiles == null || multipartFiles.isEmpty()) {
+      return new ArrayList<>();
+    }
+
+    List<UploadFile> uploadFiles = new ArrayList<>();
+    for (MultipartFile file: multipartFiles) {
+      uploadFiles.add(storeFile(file));
+    }
+    return uploadFiles;
   }
 
   /**

--- a/src/main/java/com/zerobase/nsbackend/global/fileUpload/UploadFile.java
+++ b/src/main/java/com/zerobase/nsbackend/global/fileUpload/UploadFile.java
@@ -1,5 +1,6 @@
 package com.zerobase.nsbackend.global.fileUpload;
 
+import com.zerobase.nsbackend.errand.domain.entity.ErrandImage;
 import lombok.Getter;
 
 @Getter
@@ -14,5 +15,9 @@ public class UploadFile {
 
   public static UploadFile of(String uploadFileName, String storeFileName) {
     return new UploadFile(uploadFileName, storeFileName);
+  }
+
+  public ErrandImage toErrandImage() {
+    return ErrandImage.of(storeFileName);
   }
 }

--- a/src/test/java/com/zerobase/nsbackend/global/fileUpload/FileUploadTest.java
+++ b/src/test/java/com/zerobase/nsbackend/global/fileUpload/FileUploadTest.java
@@ -18,16 +18,11 @@ class FileUploadTest extends IntegrationTest {
   @WithMockUser("USER")
   @Test
   @DisplayName("파일 업르드 테스트")
-  public void whenFileUploaded_thenVerifyStatus()
+  public void storeFile_success()
       throws Exception {
     // given
     MockMultipartFile file
-        = new MockMultipartFile(
-        "file",
-        "hello.txt",
-        MediaType.TEXT_PLAIN_VALUE,
-        "Hello, World!".getBytes()
-    );
+        = makeMultipartFile();
 
     // when
     ResultActions resultActions = mvc.perform(multipart("/images").file(file))
@@ -40,18 +35,22 @@ class FileUploadTest extends IntegrationTest {
     removeFileAfterTest(resultActions);
   }
 
+  private static MockMultipartFile makeMultipartFile() {
+    return new MockMultipartFile(
+        "file",
+        "hello.txt",
+        MediaType.TEXT_PLAIN_VALUE,
+        "Hello, World!".getBytes()
+    );
+  }
+
   @WithMockUser("USER")
   @Test
   @DisplayName("파일 조회 테스트")
   void getFile_success() throws Exception {
     // given
     MockMultipartFile file
-        = new MockMultipartFile(
-        "file",
-        "hello.txt",
-        MediaType.TEXT_PLAIN_VALUE,
-        "Hello, World!".getBytes()
-    );
+        = makeMultipartFile();
     ResultActions createAction = mvc.perform(multipart("/images").file(file));
     String newFileName = getNewFileName(createAction);
 
@@ -67,7 +66,7 @@ class FileUploadTest extends IntegrationTest {
   }
 
   /**
-   * 저장된 파일 이름을 반환합니다.
+   * ResultActions 에 있는 저장된 파일 이름을 반환합니다.
    * @param resultActions
    * @return
    * @throws Exception

--- a/src/test/java/com/zerobase/nsbackend/global/fileUpload/FileUploadTest.java
+++ b/src/test/java/com/zerobase/nsbackend/global/fileUpload/FileUploadTest.java
@@ -7,14 +7,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.zerobase.nsbackend.integrationTest.IntegrationTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
 
 class FileUploadTest extends IntegrationTest {
+  @WithMockUser("USER")
   @Test
   @DisplayName("파일 업르드 테스트")
   public void whenFileUploaded_thenVerifyStatus()
@@ -39,6 +40,7 @@ class FileUploadTest extends IntegrationTest {
     removeFileAfterTest(resultActions);
   }
 
+  @WithMockUser("USER")
   @Test
   @DisplayName("파일 조회 테스트")
   void getFile_success() throws Exception {

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.zerobase.nsbackend.integrationTest;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -10,6 +12,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 
+import com.zerobase.nsbackend.errand.domain.entity.Errand;
+import com.zerobase.nsbackend.errand.domain.entity.ErrandImage;
+import com.zerobase.nsbackend.errand.domain.repository.ErrandRepository;
 import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
 import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandUpdateRequest;
@@ -17,12 +22,15 @@ import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
 import com.zerobase.nsbackend.member.domain.Member;
 import com.zerobase.nsbackend.member.repository.MemberRepository;
 import com.zerobase.nsbackend.member.type.Authority;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -32,6 +40,8 @@ class ErrandIntegrationTest extends IntegrationTest {
 
   @Autowired
   MemberRepository memberRepository;
+  @Autowired
+  ErrandRepository errandRepository;
 
   Member member01;
   Member member02;
@@ -52,8 +62,8 @@ class ErrandIntegrationTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("의뢰 생성에 성공합니다.")
-  void createErrand_success() throws Exception {
+  @DisplayName("의뢰 생성에 성공합니다 (첨부 사진 없는 경우)")
+  void createErrand_success_when_no_images() throws Exception {
     // given
     ErrandCreateRequest createRequest = ErrandCreateRequest.builder()
         .title("testTitle")
@@ -75,6 +85,54 @@ class ErrandIntegrationTest extends IntegrationTest {
     resultActions
         .andExpect(status().isCreated())
         .andExpect(header().string("Location", CoreMatchers.startsWith("/errands/")));
+  }
+
+  @Test
+  @DisplayName("의뢰 생성에 성공합니다 (첨부사진 있는 경우)")
+  void createErrand_success_with_images() throws Exception {
+    // given
+    MockMultipartFile file1 = makeMultipartFile();
+    MockMultipartFile file2 = makeMultipartFile();
+
+    ErrandCreateRequest createRequest = ErrandCreateRequest.builder()
+        .title("testTitle")
+        .content("testContent")
+        .payDivision(PayDivision.HOURLY)
+        .pay(10000)
+        .build();
+
+    MockMultipartFile jsonRequest = new MockMultipartFile("errand", "",
+        "application/json", asJsonString(createRequest).getBytes());
+
+    // when
+    ResultActions resultActions = mvc.perform(
+            multipart("/errands")
+                .file(file1)
+                .file(file2)
+                .file(jsonRequest)
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .with(user(member01.getEmail()))
+        )
+        .andDo(print());
+
+    // then
+    MvcResult result = resultActions
+        .andExpect(status().isCreated())
+        .andExpect(header().string("Location", CoreMatchers.startsWith("/errands/")))
+        .andReturn();
+
+    Long newId = parseNewId(result);
+    Errand newErrand = errandRepository.findById(newId)
+        .orElseThrow(() -> new RuntimeException("test fail"));
+    assertThat(newErrand.getTitle()).isEqualTo(createRequest.getTitle());
+    assertThat(newErrand.getContent()).isEqualTo(createRequest.getContent());
+    assertThat(newErrand.getImages()).hasSize(2);
+    assertThat(newErrand.getPayDivision()).isEqualTo(createRequest.getPayDivision());
+    assertThat(newErrand.getPay()).isEqualTo(createRequest.getPay());
+
+    // 테스트로 업로드된 파일 삭제
+    removeFilesAfterTest(newErrand.getImages().stream().map(ErrandImage::getImageUrl)
+        .collect(Collectors.toList()));
   }
 
   @WithMockUser(roles = "USER")
@@ -228,6 +286,10 @@ class ErrandIntegrationTest extends IntegrationTest {
     MvcResult mvcResult = requestCreateErrand(title, content,payDivision,pay)
         .andReturn();
 
+    return parseNewId(mvcResult);
+  }
+
+  private Long parseNewId(MvcResult mvcResult) {
     String newErrandUri = mvcResult.getResponse().getHeader("Location");
     String newErrandId = newErrandUri.replace("/errands/", "");
     return Long.parseLong(newErrandId);
@@ -237,5 +299,25 @@ class ErrandIntegrationTest extends IntegrationTest {
     return mvc.perform(
             get("/errands/{id}", errandId)
                 .contentType(MediaType.APPLICATION_JSON));
+  }
+
+  private static MockMultipartFile makeMultipartFile() {
+    return new MockMultipartFile(
+        "images",
+        "hello.txt",
+        MediaType.TEXT_PLAIN_VALUE,
+        "Hello, World!".getBytes()
+    );
+  }
+
+  /**
+   * 리스트에 담긴 파일이름에 해당하는 파일을 삭체처리합니다.
+   * @param fileNames
+   * @throws Exception
+   */
+  public void removeFilesAfterTest(List<String> fileNames) throws Exception {
+    for(String fileName: fileNames) {
+      mvc.perform(delete("/images/{filename}", fileName));
+    }
   }
 }

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
@@ -65,7 +65,7 @@ class ErrandIntegrationTest extends IntegrationTest {
   @DisplayName("의뢰 생성에 성공합니다 (첨부 사진 없는 경우)")
   void createErrand_success_when_no_images() throws Exception {
     // given
-    ErrandCreateRequest createRequest = ErrandCreateRequest.builder()
+    ErrandCreateRequest request = ErrandCreateRequest.builder()
         .title("testTitle")
         .content("testContent")
         .payDivision(PayDivision.HOURLY)
@@ -73,13 +73,8 @@ class ErrandIntegrationTest extends IntegrationTest {
         .build();
 
     // when
-    ResultActions resultActions = mvc.perform(
-        post("/errands")
-            .with(user(member01.getEmail()))
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(asJsonString(createRequest))
-            .accept(MediaType.APPLICATION_JSON))
-        .andDo(print());
+    ResultActions resultActions = requestCreateErrand(request.getTitle(), request.getContent(),
+        request.getPayDivision(), request.getPay());
 
     // then
     resultActions
@@ -266,12 +261,15 @@ class ErrandIntegrationTest extends IntegrationTest {
         .pay(pay)
         .build();
 
+    MockMultipartFile jsonRequest = new MockMultipartFile("errand", "",
+        "application/json", asJsonString(createRequest).getBytes());
+
     return mvc.perform(
-            post("/errands")
-                .with(user(member01.getEmail()))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(asJsonString(createRequest))
-                .accept(MediaType.APPLICATION_JSON));
+        multipart("/errands")
+            .file(jsonRequest)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .with(user(member01.getEmail()))
+    );
   }
 
   /**

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
@@ -16,7 +16,7 @@ import com.zerobase.nsbackend.errand.dto.ErrandUpdateRequest;
 import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
 import com.zerobase.nsbackend.member.domain.Member;
 import com.zerobase.nsbackend.member.repository.MemberRepository;
-import com.zerobase.nsbackend.member.type.Role;
+import com.zerobase.nsbackend.member.type.Authority;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,12 +40,12 @@ class ErrandIntegrationTest extends IntegrationTest {
     member01 = Member.builder()
         .email("member01")
         .password("password")
-        .role(Role.ROLE_USER)
+        .authority(Authority.ROLE_USER)
         .build();
     member02 = Member.builder()
         .email("member02")
         .password("password")
-        .role(Role.ROLE_USER)
+        .authority(Authority.ROLE_USER)
         .build();
     memberRepository.save(member01);
     memberRepository.save(member02);

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/IntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/IntegrationTest.java
@@ -25,7 +25,7 @@ public class IntegrationTest {
 
   protected String asJsonString(final Object obj) {
     try {
-      return new ObjectMapper().writeValueAsString(obj);
+      return objectMapper.writeValueAsString(obj);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/IntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/IntegrationTest.java
@@ -20,8 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class IntegrationTest {
   @Autowired
   protected MockMvc mvc;
-  @Autowired
-  protected ObjectMapper objectMapper;
+  protected ObjectMapper objectMapper = new ObjectMapper();
 
   protected String asJsonString(final Object obj) {
     try {


### PR DESCRIPTION
## key Changes ⭐️
- 의뢰 생성 시, 의뢰 사진 업로드 기능을 추가하였습니다.
- 의뢰 사진 엔티티 (ErrandImage)
   - 의뢰 엔티티와 의뢰 사진 엔티티를 일대다 연관관계를 맺습니다.
   - 관계의 주인을 다 쪽(의뢰)으로 설정하였습니다. 
- 사진 입력값 : List<MultipartFile>
   - 의뢰 사진을 여러장 업로드 시키기 위해 List로 입력받습니다.

<br/>

## To Reviewers 🙏
- MockMvc로 MultipartFile 요청 테스트를 구현할 때 아래 링크를 참고하였습니다.
https://stackoverflow.com/questions/21800726/using-spring-mvc-test-to-unit-test-multipart-post-request 

<br/>

related: #36