### PR TITLE
refactor : Member 영속성관련 리팩토리

### DIFF
--- a/src/main/java/com/zerobase/nsbackend/member/controller/MemberController.java
+++ b/src/main/java/com/zerobase/nsbackend/member/controller/MemberController.java
@@ -34,30 +34,30 @@ public class MemberController {
 
     @GetMapping()
     public ResponseEntity<GetUserResponse> getUserInfo(@AuthenticationPrincipal Member member){
-        GetUserResponse userInfo = memberService.getUserInfo(member);
+        GetUserResponse userInfo = memberService.getUserInfo(member.getEmail());
         return ResponseEntity.ok(userInfo);
     }
     @PutMapping("/profileimg")
     public ResponseEntity<GetUserResponse> putProfileImg(@RequestBody @Valid PutProfileImgRequest request
         , @AuthenticationPrincipal Member member){
-        memberService.updateUserImg(request, member);
+        memberService.updateUserImg(request, member.getEmail());
         return ResponseEntity.ok().build();
     }
     @PutMapping("/nickname")
     public ResponseEntity<GetUserResponse> putUserNickname(@RequestBody @Valid PutUserNicknameRequest request
     , @AuthenticationPrincipal Member member){
-        memberService.updateUserNickname(request, member);
+        memberService.updateUserNickname(request, member.getEmail());
         return ResponseEntity.ok().build();
     }
     @PutMapping("/address")
     public ResponseEntity<GetUserResponse> putUserAddress(@RequestBody @Valid PutUserAddressRequest request
     , @AuthenticationPrincipal Member member){
-        memberService.updateUserAddress(request, member);
+        memberService.updateUserAddress(request, member.getEmail());
         return ResponseEntity.ok().build();
     }
     @DeleteMapping()
     public ResponseEntity<GetUserResponse> deleteUserInfo(@AuthenticationPrincipal Member member){
-        memberService.deleteUser(member);
+        memberService.deleteUser(member.getEmail());
         return ResponseEntity.ok().build();
     }
 
@@ -65,7 +65,7 @@ public class MemberController {
     public ResponseEntity<List<InterestBoardResponse>> getInterestBoard(
         @AuthenticationPrincipal Member member){
         List<InterestBoardResponse> allInterestBoard = this.interestBoardService.getAllInterestBoard(
-            member);
+            member.getEmail());
         return ResponseEntity.ok(allInterestBoard);
     }
 
@@ -73,7 +73,7 @@ public class MemberController {
     public ResponseEntity<List<InterestBoardResponse>> addInterestBoard(@PathVariable Long id
         , @AuthenticationPrincipal Member member){
         List<InterestBoardResponse> interestBoardResponseList = this.interestBoardService.addInterestBoard(
-            id, member);
+            id, member.getEmail());
         return ResponseEntity.ok(interestBoardResponseList);
     }
 
@@ -81,7 +81,7 @@ public class MemberController {
     public ResponseEntity<List<InterestBoardResponse>> deleteInterestBoard(@PathVariable Long id
         , @AuthenticationPrincipal Member member){
         List<InterestBoardResponse> interestBoardResponseList = this.interestBoardService.deleteInterestBoard(
-            id, member);
+            id, member.getEmail());
         return ResponseEntity.ok(interestBoardResponseList);
     }
 

--- a/src/main/java/com/zerobase/nsbackend/member/domain/Member.java
+++ b/src/main/java/com/zerobase/nsbackend/member/domain/Member.java
@@ -47,11 +47,9 @@ public class Member extends BaseTimeEntity implements UserDetails {
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "member_address_id")
     private MemberAddress memberAddress;
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER,
-        mappedBy = "member")
-    private List<InterestBoard> interestBoards;
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "member")
+    private List<InterestBoard> interestBoards = new ArrayList<>();
     private boolean isDeleted;
-
     public void updateUserNickname(String nickname){
         this.nickname = nickname;
     }

--- a/src/main/java/com/zerobase/nsbackend/member/service/InterestBoardService.java
+++ b/src/main/java/com/zerobase/nsbackend/member/service/InterestBoardService.java
@@ -23,7 +23,9 @@ public class InterestBoardService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public List<InterestBoardResponse> addInterestBoard(Long errandId, Member member){
+    public List<InterestBoardResponse> addInterestBoard(Long errandId, String email){
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
         List<InterestBoard> interestBoardList = member.getInterestBoards();
         Errand errand = this.errandRepository.findById(errandId)
             .orElseThrow(() -> new IllegalArgumentException(ErrorCode.ERRAND_NOT_FOUND.getDescription()));
@@ -32,15 +34,19 @@ public class InterestBoardService {
         }
         InterestBoard interestBoard = new InterestBoard(member,errand);
         interestBoardList.add(interestBoard);
-        memberRepository.save(member);
         return convertInterestBoardResponse(member.getInterestBoards());
     }
-    public List<InterestBoardResponse> getAllInterestBoard(Member member){
+
+    public List<InterestBoardResponse> getAllInterestBoard(String email){
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
         return convertInterestBoardResponse(member.getInterestBoards());
     }
 
     @Transactional
-    public List<InterestBoardResponse> deleteInterestBoard(Long errandId, Member member){
+    public List<InterestBoardResponse> deleteInterestBoard(Long errandId, String email){
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
         List<InterestBoard> interestBoardList = member.getInterestBoards();
         Errand errand = this.errandRepository.findById(errandId)
             .orElseThrow(() -> new IllegalArgumentException(ErrorCode.ERRAND_NOT_FOUND.getDescription()));
@@ -48,7 +54,6 @@ public class InterestBoardService {
             throw new IllegalArgumentException(ErrorCode.NO_EXIST_INTEREST_BOARD.getDescription());
         }
         member.deleteInterestBoard(errand);
-        memberRepository.save(member);
         return convertInterestBoardResponse(member.getInterestBoards());
     }
 

--- a/src/main/java/com/zerobase/nsbackend/member/service/MemberService.java
+++ b/src/main/java/com/zerobase/nsbackend/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.zerobase.nsbackend.member.service;
 
+import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
 import com.zerobase.nsbackend.member.domain.Member;
 import com.zerobase.nsbackend.member.domain.MemberAddress;
 import com.zerobase.nsbackend.member.dto.GetUserResponse;
@@ -8,6 +9,7 @@ import com.zerobase.nsbackend.member.dto.PutUserAddressRequest;
 import com.zerobase.nsbackend.member.dto.PutUserNicknameRequest;
 import com.zerobase.nsbackend.member.repository.MemberAddressRepository;
 import com.zerobase.nsbackend.member.repository.MemberRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,7 +22,9 @@ public class MemberService {
     private final MemberAddressRepository memberAddressRepository;
     private final MemberRepository memberRepository;
 
-    public GetUserResponse getUserInfo(Member member){
+    public GetUserResponse getUserInfo(String email){
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
         return GetUserResponse.builder()
             .email(member.getEmail())
             .nickname(member.getNickname())
@@ -32,32 +36,36 @@ public class MemberService {
     }
 
     @Transactional
-    public Member updateUserNickname(PutUserNicknameRequest request, Member member){
+    public Member updateUserNickname(PutUserNicknameRequest request, String email){
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
         member.updateUserNickname(request.getNickname());
-        memberRepository.save(member);
         return member;
     }
 
     @Transactional
-    public Member updateUserImg(PutProfileImgRequest request, Member member){
+    public Member updateUserImg(PutProfileImgRequest request, String email){
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
         member.updateUserImg(request.getImg());
-        memberRepository.save(member);
         return member;
     }
 
     @Transactional
-    public MemberAddress updateUserAddress(PutUserAddressRequest request, Member member){
+    public MemberAddress updateUserAddress(PutUserAddressRequest request, String email){
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
         MemberAddress memberAddress = member.getMemberAddress();
         memberAddress.updateUserAddress(request.getLatitude(),
             request.getLongitude(), request.getStreetNameAddress());
-        memberAddressRepository.save(memberAddress);
         return memberAddress;
     }
 
     @Transactional
-    public Member deleteUser(Member member){
+    public Member deleteUser(String email){
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
         member.deleteUser();
-        memberRepository.save(member);
         return member;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         format_sql: true
         show_sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     open-in-view: false
   jwt:
     secret: cc40a3791cf94e649344be45eb1292a2

--- a/src/test/java/com/zerobase/nsbackend/member/service/InterestBoardServiceTest.java
+++ b/src/test/java/com/zerobase/nsbackend/member/service/InterestBoardServiceTest.java
@@ -51,6 +51,8 @@ class InterestBoardServiceTest {
         //given
         given(errandRepository.findById(any()))
             .willReturn(Optional.ofNullable(errand));
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(member));
         List<InterestBoardResponse> list = new ArrayList<>();
         assert errand != null;
         InterestBoardResponse build = InterestBoardResponse.builder()
@@ -60,7 +62,7 @@ class InterestBoardServiceTest {
         list.add(build);
         //when
         List<InterestBoardResponse> responses = this.interestBoardService.addInterestBoard(
-            1L, member);
+            1L, member.getEmail());
         //then
         assertEquals(list.get(0).getErrandId(),responses.get(0).getErrandId());
         assertEquals(list.get(0).getErrandTitle(),responses.get(0).getErrandTitle());
@@ -71,9 +73,11 @@ class InterestBoardServiceTest {
         //given
         given(errandRepository.findById(any()))
             .willReturn(Optional.empty());
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(member));
         //when
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> interestBoardService.addInterestBoard(1L, member));
+            () -> interestBoardService.addInterestBoard(1L, member.getEmail()));
         //then
         assertEquals(ErrorCode.ERRAND_NOT_FOUND.getDescription(),exception.getMessage());
     }
@@ -92,9 +96,11 @@ class InterestBoardServiceTest {
             .password("encodePassword")
             .interestBoards(list)
             .build();
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(build));
         //when
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> interestBoardService.addInterestBoard(1L, build));
+            () -> interestBoardService.addInterestBoard(1L, build.getEmail()));
         //then
         assertEquals(ErrorCode.EXIST_INTEREST_BOARD.getDescription(),exception.getMessage());
     }
@@ -111,9 +117,11 @@ class InterestBoardServiceTest {
             .password("encodePassword")
             .interestBoards(list)
             .build();
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(build));
         //when
         List<InterestBoardResponse> allInterestBoard = this.interestBoardService.getAllInterestBoard(
-            build);
+            build.getEmail());
         assertEquals(errand.getId(),allInterestBoard.get(0).getErrandId());
         assertEquals(errand.getTitle(),allInterestBoard.get(0).getErrandTitle());
     }
@@ -132,9 +140,11 @@ class InterestBoardServiceTest {
             .password("encodePassword")
             .interestBoards(list)
             .build();
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(build));
         //when
         List<InterestBoardResponse> responses = this.interestBoardService.deleteInterestBoard(
-            1L, build);
+            1L, build.getEmail());
         //then
         assertEquals(new ArrayList<>(),responses);
     }
@@ -145,9 +155,11 @@ class InterestBoardServiceTest {
         //given
         given(errandRepository.findById(any()))
             .willReturn(Optional.empty());
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(member));
         //when
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> interestBoardService.deleteInterestBoard(1L, member));
+            () -> interestBoardService.deleteInterestBoard(1L, member.getEmail()));
         //then
         assertEquals(ErrorCode.ERRAND_NOT_FOUND.getDescription(), exception.getMessage());
     }
@@ -157,9 +169,11 @@ class InterestBoardServiceTest {
         //given
         given(errandRepository.findById(any()))
             .willReturn(Optional.ofNullable(errand));
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(member));
         //when
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> interestBoardService.deleteInterestBoard(1L, member));
+            () -> interestBoardService.deleteInterestBoard(1L, member.getEmail()));
         //then
         assertEquals(ErrorCode.NO_EXIST_INTEREST_BOARD.getDescription(),exception.getMessage());
     }

--- a/src/test/java/com/zerobase/nsbackend/member/service/MemberServiceTest.java
+++ b/src/test/java/com/zerobase/nsbackend/member/service/MemberServiceTest.java
@@ -45,9 +45,10 @@ class MemberServiceTest {
     @Test
     void getUserInfo() {
         //given
-
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(member));
         //when
-        GetUserResponse userInfo = memberService.getUserInfo(member);
+        GetUserResponse userInfo = memberService.getUserInfo("aa@naver.com");
         //then
         assertEquals("aa@naver.com",userInfo.getEmail());
         assertEquals(1,userInfo.getLongitude());
@@ -58,12 +59,12 @@ class MemberServiceTest {
     @Test
     void updateUserNickname() {
         //given
-        given(memberRepository.save(member))
-            .willReturn(member);
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(member));
         PutUserNicknameRequest request = new PutUserNicknameRequest();
         request.setNickname("update");
         //when
-        Member updated = memberService.updateUserNickname(request, member);
+        Member updated = memberService.updateUserNickname(request, "aa@naver.com");
         //then
         assertEquals("update",updated.getNickname());
         assertEquals(member.getEmail(),updated.getEmail());
@@ -72,12 +73,12 @@ class MemberServiceTest {
     @Test
     void updateUserImg() {
         //given
-        given(memberRepository.save(member))
-            .willReturn(member);
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(member));
         PutProfileImgRequest request = new PutProfileImgRequest();
         request.setImg("set");
         //when
-        Member updated = memberService.updateUserImg(request, member);
+        Member updated = memberService.updateUserImg(request, member.getEmail());
         //then
         assertEquals("set",updated.getProfileImage());
         assertEquals(member.getEmail(),updated.getEmail());
@@ -86,12 +87,14 @@ class MemberServiceTest {
     @Test
     void updateUserAddress() {
         //given
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(member));
         PutUserAddressRequest request = PutUserAddressRequest.builder()
             .latitude(12.123f)
             .longitude(32.123f)
             .streetNameAddress("updateStreet").build();
         //when
-        MemberAddress updated = memberService.updateUserAddress(request, member);
+        MemberAddress updated = memberService.updateUserAddress(request, member.getEmail());
         //then
         assertEquals(12.123f, updated.getLatitude());
         assertEquals(32.123f, updated.getLongitude());
@@ -101,10 +104,10 @@ class MemberServiceTest {
     @Test
     void deleteUser() {
         //given
-        given(memberRepository.save(member))
-            .willReturn(member);
+        given(memberRepository.findByEmail(any()))
+            .willReturn(Optional.ofNullable(member));
         //when
-        Member deleteUser = memberService.deleteUser(member);
+        Member deleteUser = memberService.deleteUser(member.getEmail());
         //then
         assertTrue(deleteUser.isDeleted());
     }


### PR DESCRIPTION
## key Changes ⭐️
- Member을 직접적으로 받는 service에 대한 로직 수정
- 로직 수정에 따른 테스트 코드 수정

<br/>

## To Reviewers 🙏
- 이전까지의 로직은 @AuthenticationPrincipal로 Member을 받아 이것을 직접 service에 넣어주는 방식으로 코드를 작성하였습니다. 그 이유는 외부에서 받아올 수 있는데 내부에서 다시 조회하게 되는 것이 성능에 부정적일 것이라고 생각이 되었습니다.
- 로직 수정의 이유는 두번을 조회하더라도 전체 애플리케이션에 미치는 영향은 미미할 것이라고 생각이되었기 때문입니다. 그래서 엔티티의 영속성을 위해서라도 트랜잭션이 있는 곳에서 처음부터 다시 조회하는 것이 좋을 것이라고 생각되었습니다.
<br/>
