### PR TITLE
의뢰 좋아요 & 의뢰생성컬럼추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 dependencyManagement {
     imports {

--- a/src/main/java/com/zerobase/nsbackend/chatting/domain/service/ChattingRoomService.java
+++ b/src/main/java/com/zerobase/nsbackend/chatting/domain/service/ChattingRoomService.java
@@ -5,9 +5,7 @@ import static com.zerobase.nsbackend.chatting.type.ChattingRoomCreateStatus.CHAT
 
 import com.zerobase.nsbackend.chatting.domain.entity.ChattingContent;
 import com.zerobase.nsbackend.chatting.domain.entity.ChattingRoom;
-import com.zerobase.nsbackend.chatting.domain.repository.ChattingContentRepository;
 import com.zerobase.nsbackend.chatting.domain.repository.ChattingRoomRepository;
-import com.zerobase.nsbackend.chatting.dto.ChattingRoomAllResponse;
 import com.zerobase.nsbackend.chatting.dto.ChattingRoomCreateResponse;
 import com.zerobase.nsbackend.errand.domain.entity.Errand;
 import com.zerobase.nsbackend.errand.domain.repository.ErrandRepository;

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
@@ -109,8 +109,9 @@ public class ErrandService {
     errand.removeHashtag(tag);
   }
 
-  public List<Errand> getAllErrands() {
-    return errandRepository.findAll();
+  public List<ErrandDto> getAllErrands() {
+    return errandRepository.findErrandAllWithImagesAndHashTag()
+        .stream().map(ErrandDto::from).collect(Collectors.toList());
   }
 
   @Transactional

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
@@ -9,6 +9,7 @@ import com.zerobase.nsbackend.errand.domain.repository.ErrandRepository;
 import com.zerobase.nsbackend.errand.dto.ErrandChangAddressRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
 import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
+import com.zerobase.nsbackend.errand.dto.ErrandDto;
 import com.zerobase.nsbackend.errand.dto.ErrandUpdateRequest;
 import com.zerobase.nsbackend.global.auth.AuthManager;
 import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
@@ -56,8 +57,14 @@ public class ErrandService {
   }
 
   public Errand getErrand(Long id) {
-    return errandRepository.findById(id)
+    return errandRepository.findErrandWithImagesAndHashTagById(id)
         .orElseThrow(() -> new IllegalArgumentException(ErrorCode.ERRAND_NOT_FOUND.getDescription()));
+  }
+
+  @Transactional
+  public ErrandDto getErrandDto(Long id) {
+    Errand errand = getErrand(id);
+    return ErrandDto.from(errand);
   }
 
   @Transactional

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
@@ -119,4 +119,11 @@ public class ErrandService {
     Errand errand = getErrand(id);
     errand.changeAddress(request.toAddress());
   }
+
+  @Transactional
+  public void likeErrand(Long id) {
+    Member member = getMemberFromAuth();
+    Errand errand = getErrand(id);
+    errand.like(member);
+  }
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
@@ -120,10 +120,17 @@ public class ErrandService {
     errand.changeAddress(request.toAddress());
   }
 
+  /**
+   * 좋아요 처리를 합니다.
+   * @param id
+   * @return 로그인한 회원의 해당 의뢰에 대한 좋아요 여부
+   */
   @Transactional
-  public void likeErrand(Long id) {
+  public boolean likeErrand(Long id) {
     Member member = getMemberFromAuth();
     Errand errand = getErrand(id);
     errand.like(member);
+
+    return errand.isLiked(member);
   }
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
@@ -35,7 +35,6 @@ public class ErrandService {
 
   @Transactional
   public Errand createErrand(ErrandCreateRequest request, List<MultipartFile> imageRequest) {
-    // Security Context로 부터 인증된 유저 정보 받아오기
     Member member = getMemberFromAuth();
 
     // 아미지 업로드
@@ -64,7 +63,9 @@ public class ErrandService {
   @Transactional
   public ErrandDto getErrandDto(Long id) {
     Errand errand = getErrand(id);
-    return ErrandDto.from(errand);
+    Member memberFromAuth = getMemberFromAuth();
+    boolean isLiked = errand.checkLiked(memberFromAuth);
+    return ErrandDto.from(errand, isLiked);
   }
 
   @Transactional
@@ -109,9 +110,11 @@ public class ErrandService {
     errand.removeHashtag(tag);
   }
 
+  @Transactional
   public List<ErrandDto> getAllErrands() {
+    Member member = getMemberFromAuth();
     return errandRepository.findErrandAllWithImagesAndHashTag()
-        .stream().map(ErrandDto::from).collect(Collectors.toList());
+        .stream().map(errand -> ErrandDto.from(errand, errand.checkLiked(member))).collect(Collectors.toList());
   }
 
   @Transactional
@@ -131,6 +134,6 @@ public class ErrandService {
     Errand errand = getErrand(id);
     errand.like(member);
 
-    return errand.isLiked(member);
+    return errand.checkLiked(member);
   }
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
@@ -15,7 +15,6 @@ import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
-import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -113,7 +112,12 @@ public class Errand extends BaseTimeEntity {
     likedMembers.add(likedMember);
   }
 
-  public boolean isLiked(Member member) {
+  /**
+   * 회원이 해당 의뢰에 대해 좋아요를 눌렀는지 체크합니다.
+   * @param member
+   * @return
+   */
+  public boolean checkLiked(Member member) {
     return likedMembers.contains(LikedMember.of(this, member));
   }
 

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
@@ -8,6 +8,7 @@ import com.zerobase.nsbackend.member.domain.Member;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.persistence.AttributeOverride;
@@ -66,6 +67,10 @@ public class Errand extends BaseTimeEntity {
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn(name = "ERRAND_ID")
   private Set<ErrandHashtag> hashtags = new HashSet<>();
+
+  @Builder.Default
+  @OneToMany(mappedBy = "errand", cascade = CascadeType.ALL, orphanRemoval = true)
+  private Set<LikedMember> likedMembers = new HashSet<>();
   private Integer viewCount;
 
   public void edit(String title, String content, PayDivision payDivision, Integer pay) {
@@ -97,6 +102,32 @@ public class Errand extends BaseTimeEntity {
 
   public void changeAddress(Address address) {
     this.address = address;
+  }
+
+  public void like(Member member) {
+    LikedMember likedMember = LikedMember.of(this, member);
+    if (likedMembers.contains(likedMember)) {
+      likedMembers.remove(likedMember);
+      return;
+    }
+    likedMembers.add(likedMember);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Errand errand = (Errand) o;
+    return id.equals(errand.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
   }
 }
 

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
@@ -5,6 +5,7 @@ import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
 import com.zerobase.nsbackend.global.BaseTimeEntity;
 import com.zerobase.nsbackend.global.vo.Address;
 import com.zerobase.nsbackend.member.domain.Member;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -53,6 +54,7 @@ public class Errand extends BaseTimeEntity {
   @Enumerated(EnumType.STRING)
   private PayDivision payDivision;
   private Integer pay;
+  private LocalDate deadLine;
   @Embedded
   @AttributeOverrides({
       @AttributeOverride(name = "streetAddress", column = @Column(name = "street_address")),

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
@@ -121,6 +121,10 @@ public class Errand extends BaseTimeEntity {
     return likedMembers.contains(LikedMember.of(this, member));
   }
 
+  public Integer getLikedCount() {
+    return likedMembers.size();
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
@@ -113,6 +113,10 @@ public class Errand extends BaseTimeEntity {
     likedMembers.add(likedMember);
   }
 
+  public boolean isLiked(Member member) {
+    return likedMembers.contains(LikedMember.of(this, member));
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/LikedMember.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/LikedMember.java
@@ -1,0 +1,50 @@
+package com.zerobase.nsbackend.errand.domain.entity;
+
+import com.zerobase.nsbackend.member.domain.Member;
+import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class LikedMember {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @ManyToOne
+  private Errand errand;
+
+  @ManyToOne
+  private Member member;
+
+  private LikedMember(Errand errand, Member member) {
+    this.errand = errand;
+    this.member = member;
+  }
+
+  public static LikedMember of(Errand errand, Member member){
+    return new LikedMember(errand, member);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LikedMember that = (LikedMember) o;
+    return errand.equals(that.errand) && member.equals(that.member);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(errand, member);
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
@@ -1,8 +1,17 @@
 package com.zerobase.nsbackend.errand.domain.repository;
 
 import com.zerobase.nsbackend.errand.domain.entity.Errand;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ErrandRepository extends JpaRepository<Errand, Long> {
-
+  @Query("select e "
+      + "from Errand e"
+      + " left join fetch e.images "
+      + " left join fetch e.hashtags "
+      + " where e.id = :id")
+  Optional<Errand> findErrandWithImagesAndHashTagById(@Param("id") Long id);
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
@@ -14,4 +14,10 @@ public interface ErrandRepository extends JpaRepository<Errand, Long> {
       + " left join fetch e.hashtags "
       + " where e.id = :id")
   Optional<Errand> findErrandWithImagesAndHashTagById(@Param("id") Long id);
+
+  @Query("select e "
+      + "from Errand e"
+      + " left join fetch e.images "
+      + " left join fetch e.hashtags ")
+  Optional<Errand> findErrandAllWithImagesAndHashTag();
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandCreateRequest.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandCreateRequest.java
@@ -1,11 +1,16 @@
 package com.zerobase.nsbackend.errand.dto;
 
 import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Setter
 @NoArgsConstructor
@@ -17,4 +22,8 @@ public class ErrandCreateRequest {
   private String content;
   private PayDivision payDivision;
   private Integer pay;
+  @DateTimeFormat(pattern = "yyyy-MM-dd")
+  private Date deadLine;
+  @Builder.Default
+  private List<String> hashtags = new ArrayList<>();
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
@@ -22,6 +22,7 @@ public class ErrandDto {
   private List<String> hashtags;
   private AddressDto address;
   private boolean isLiked;
+  private Integer likedCount;
   private LocalDateTime createdAt;
 
   public static ErrandDto from(Errand errand) {
@@ -34,6 +35,7 @@ public class ErrandDto {
         .pay(errand.getPay())
         .hashtags(errand.getHashtagsAsStringList())
         .address(AddressDto.from(errand.getAddress()))
+        .likedCount(errand.getLikedCount())
         .build();
   }
 

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
@@ -3,11 +3,14 @@ package com.zerobase.nsbackend.errand.dto;
 import com.zerobase.nsbackend.errand.domain.entity.Errand;
 import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
 import com.zerobase.nsbackend.global.dto.AddressDto;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
@@ -19,6 +22,7 @@ public class ErrandDto {
   private List<String> images;
   private PayDivision payDivision;
   private Integer pay;
+  private LocalDate deadLine;
   private List<String> hashtags;
   private AddressDto address;
   private boolean isLiked;
@@ -33,6 +37,7 @@ public class ErrandDto {
         .images(errand.getImagesAsStringList())
         .payDivision(errand.getPayDivision())
         .pay(errand.getPay())
+        .deadLine(errand.getDeadLine())
         .hashtags(errand.getHashtagsAsStringList())
         .address(AddressDto.from(errand.getAddress()))
         .likedCount(errand.getLikedCount())

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
@@ -21,6 +21,7 @@ public class ErrandDto {
   private Integer pay;
   private List<String> hashtags;
   private AddressDto address;
+  private boolean isLiked;
   private LocalDateTime createdAt;
 
   public static ErrandDto from(Errand errand) {
@@ -34,5 +35,27 @@ public class ErrandDto {
         .hashtags(errand.getHashtagsAsStringList())
         .address(AddressDto.from(errand.getAddress()))
         .build();
+  }
+
+  /**
+   * Errand 엔티티와 Like 여부와 함께 ErrandDto를 만듭니다.
+   * @param errand
+   * @param isLiked
+   * @return
+   */
+  public static ErrandDto from(Errand errand, boolean isLiked) {
+    ErrandDto errandDto = ErrandDto.from(errand);
+    errandDto.setIsLiked(isLiked);
+    return errandDto;
+  }
+
+  /**
+   * isLiked를 변경합니다.
+   * 좋아요 여부를 확인하려면 현재 로그인한 유저를 받아와야 하는데,
+   * DTO 내에 AuthManager 의존성을 추가해 주는것이 맞지 않다고 생각했습니다.
+   * @param isLiked
+   */
+  private void setIsLiked(boolean isLiked) {
+    this.isLiked = isLiked;
   }
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class ErrandDto {
   private Long id;

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/LikeErrandResponse.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/LikeErrandResponse.java
@@ -1,0 +1,18 @@
+package com.zerobase.nsbackend.errand.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class LikeErrandResponse {
+  private boolean isLiked;
+
+  private LikeErrandResponse(boolean isLiked) {
+    this.isLiked = isLiked;
+  }
+
+  public static LikeErrandResponse of(boolean isLiked) {
+    return new LikeErrandResponse(isLiked);
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
@@ -49,7 +49,7 @@ public class ErrandController {
 
   @GetMapping("/{id}")
   public ResponseEntity<ErrandDto> readErrand(@PathVariable Long id) {
-    return ResponseEntity.ok(ErrandDto.from(errandService.getErrand(id)));
+    return ResponseEntity.ok(errandService.getErrandDto(id));
   }
 
   @PutMapping("/{id}")

--- a/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
@@ -6,6 +6,7 @@ import com.zerobase.nsbackend.errand.dto.ErrandChangAddressRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandDto;
 import com.zerobase.nsbackend.errand.dto.ErrandUpdateRequest;
+import com.zerobase.nsbackend.errand.dto.LikeErrandResponse;
 import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -85,8 +86,7 @@ public class ErrandController {
   }
 
   @PostMapping("/{id}/like")
-  public ResponseEntity<Void> likeErrand(@PathVariable Long id) {
-    errandService.likeErrand(id);
-    return ResponseEntity.ok().build();
+  public ResponseEntity<LikeErrandResponse> likeErrand(@PathVariable Long id) {
+    return ResponseEntity.ok(LikeErrandResponse.of(errandService.likeErrand(id)));
   }
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
@@ -83,4 +83,10 @@ public class ErrandController {
     errandService.changeAddress(id, request);
     return ResponseEntity.ok().build();
   }
+
+  @PostMapping("/{id}/like")
+  public ResponseEntity<Void> likeErrand(@PathVariable Long id) {
+    errandService.likeErrand(id);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
@@ -43,8 +43,7 @@ public class ErrandController {
 
   @GetMapping
   public ResponseEntity<List<ErrandDto>> readAllErrand() {
-    return ResponseEntity.ok(errandService.getAllErrands().stream().map(ErrandDto::from).collect(
-        Collectors.toList()));
+    return ResponseEntity.ok(errandService.getAllErrands());
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/zerobase/nsbackend/global/dto/AddressDto.java
+++ b/src/main/java/com/zerobase/nsbackend/global/dto/AddressDto.java
@@ -2,7 +2,9 @@ package com.zerobase.nsbackend.global.dto;
 
 import com.zerobase.nsbackend.global.vo.Address;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class AddressDto {
   private String streetAddress;

--- a/src/main/java/com/zerobase/nsbackend/member/domain/Member.java
+++ b/src/main/java/com/zerobase/nsbackend/member/domain/Member.java
@@ -6,6 +6,7 @@ import com.zerobase.nsbackend.member.type.Authority;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -94,5 +95,22 @@ public class Member extends BaseTimeEntity implements UserDetails {
     @Override
     public boolean isEnabled() {
         return !isDeleted;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Member member = (Member) o;
+        return id.equals(member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/test/java/com/zerobase/nsbackend/auth/authHttp.http
+++ b/src/test/java/com/zerobase/nsbackend/auth/authHttp.http
@@ -1,5 +1,10 @@
+## url 설정
+## localhost url: localhost:8080
+## dev url : 3.34.174.154:8080
+    > {% client.global.set("host", "localhost:8080"); %}
+
 ### 회원가입 요청
-POST http://localhost:8080/auth/signup
+POST http://{{host}}/auth/signup
 Content-Type: application/json
 
 {
@@ -9,10 +14,12 @@ Content-Type: application/json
 }
 
 ### 로그인 요청
-POST http://localhost:8080/auth/signin
+POST http://{{host}}/auth/signin
 Content-Type: application/json
 
 {
 "email" : "test01@gmail.com",
 "password" : "111111"
 }
+
+> {% client.global.set("auth_token", response.body.token); %}

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
@@ -21,6 +21,7 @@ import com.zerobase.nsbackend.errand.domain.repository.ErrandRepository;
 import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
 import com.zerobase.nsbackend.errand.dto.ErrandChangAddressRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
+import com.zerobase.nsbackend.errand.dto.ErrandDto;
 import com.zerobase.nsbackend.errand.dto.ErrandUpdateRequest;
 import com.zerobase.nsbackend.global.auth.AuthManager;
 import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
@@ -28,7 +29,13 @@ import com.zerobase.nsbackend.global.vo.Address;
 import com.zerobase.nsbackend.member.domain.Member;
 import com.zerobase.nsbackend.member.repository.MemberRepository;
 import com.zerobase.nsbackend.member.type.Authority;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hamcrest.CoreMatchers;
@@ -37,7 +44,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
@@ -46,19 +55,20 @@ import org.springframework.test.web.servlet.ResultActions;
 @WithMockUser
 @DisplayName("의뢰 통합 테스트")
 class ErrandIntegrationTest extends IntegrationTest {
-
+  SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
   @Autowired
   MemberRepository memberRepository;
   @Autowired
   ErrandRepository errandRepository;
-
   @MockBean
   AuthManager authManager;
 
   Member member01;
   Member member02;
+
+  ErrandCreateRequest createRequest1;
   @BeforeEach
-  void init() {
+  void init() throws ParseException {
     member01 = Member.builder()
         .email("member01")
         .password("password")
@@ -71,23 +81,25 @@ class ErrandIntegrationTest extends IntegrationTest {
         .build();
     memberRepository.save(member01);
     memberRepository.save(member02);
+
+    createRequest1 = ErrandCreateRequest.builder()
+        .title("testTitle")
+        .content("testContent")
+        .payDivision(PayDivision.HOURLY)
+        .pay(10000)
+        .deadLine(dateFormat.parse("2024-01-29"))
+        .hashtags(List.of("알바", "이사"))
+        .build();
   }
 
   @Test
   @DisplayName("의뢰 생성에 성공합니다 (첨부 사진 없는 경우)")
   void createErrand_success_when_no_images() throws Exception {
     // given
-    ErrandCreateRequest request = ErrandCreateRequest.builder()
-        .title("testTitle")
-        .content("testContent")
-        .payDivision(PayDivision.HOURLY)
-        .pay(10000)
-        .build();
     when(authManager.getUsername()).thenReturn(member01.getEmail());
 
     // when
-    ResultActions resultActions = requestCreateErrand(request.getTitle(), request.getContent(),
-        request.getPayDivision(), request.getPay());
+    ResultActions resultActions = requestCreateErrand(createRequest1);
 
     // then
     resultActions
@@ -102,12 +114,7 @@ class ErrandIntegrationTest extends IntegrationTest {
     MockMultipartFile file1 = makeMultipartFile();
     MockMultipartFile file2 = makeMultipartFile();
 
-    ErrandCreateRequest createRequest = ErrandCreateRequest.builder()
-        .title("testTitle")
-        .content("testContent")
-        .payDivision(PayDivision.HOURLY)
-        .pay(10000)
-        .build();
+    ErrandCreateRequest createRequest = createRequest1;
     when(authManager.getUsername()).thenReturn(member01.getEmail());
 
     MockMultipartFile jsonRequest = new MockMultipartFile("errand", "",
@@ -147,34 +154,35 @@ class ErrandIntegrationTest extends IntegrationTest {
   @DisplayName("의뢰 ID로 의뢰 조회에 성공합니다.")
   void readErrandById_success() throws Exception {
     // given
-    String title = "testTitle";
-    String content = "testContent";
-    PayDivision payDivision = PayDivision.HOURLY;
-    Integer pay = 10000;
-    Long errandId = createErrandForGiven(title, content, payDivision, pay);
+    Long errandId = createErrandForGiven(createRequest1);
 
     // when
-    ResultActions resultActions = requestGetErrand(errandId);
+    MvcResult mvcResult = requestGetErrand(errandId)
+        .andReturn();
 
     // then
-    resultActions
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(errandId))
-        .andExpect(jsonPath("$.title").value(is(title)))
-        .andExpect(jsonPath("$.content").value(is(content)))
-        .andExpect(jsonPath("$.payDivision").value(is(payDivision.name())))
-        .andExpect(jsonPath("$.pay").value(is(pay)));
+    assertThat(mvcResult.getResponse().getStatus()).isEqualTo(HttpStatus.OK.value());
+
+    MockHttpServletResponse mockHttpServletResponse = mvcResult.getResponse();
+    mockHttpServletResponse.setCharacterEncoding("UTF-8");
+    String contentAsString = mockHttpServletResponse.getContentAsString();
+    ErrandDto result = objectMapper.readValue(contentAsString, ErrandDto.class);
+
+    assertThat(result.getTitle()).isEqualTo(createRequest1.getTitle());
+    assertThat(result.getContent()).isEqualTo(createRequest1.getContent());
+    assertThat(result.getPayDivision()).isEqualTo(createRequest1.getPayDivision());
+    assertThat(result.getPay()).isEqualTo(createRequest1.getPay());
+    assertThat(result.getHashtags()).usingRecursiveComparison().isEqualTo(createRequest1.getHashtags());
+    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    assertThat(result.getDeadLine().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+        .isEqualTo(dateFormat.format(createRequest1.getDeadLine()));
   }
 
   @Test
   @DisplayName("의뢰ID로 의뢰 조회 시, 의뢰 ID가 없어서 실패합니다.")
   void readErrandById_fail_because_errand_not_found() throws Exception {
     // given
-    String title = "testTitle";
-    String content = "testContent";
-    PayDivision payDivision = PayDivision.HOURLY;
-    Integer pay = 10000;
-    Long errandId = createErrandForGiven(title, content, payDivision, pay);
+    Long errandId = createErrandForGiven(createRequest1);
 
     Long notFoundId = 100L;
 
@@ -191,7 +199,7 @@ class ErrandIntegrationTest extends IntegrationTest {
   @DisplayName("의뢰 성공적으로 수정합니다.")
   void updateErrand_success() throws Exception {
     // given
-    Long errandId = createErrandForGiven("testTitle", "testContent", PayDivision.HOURLY, 10000);
+    Long errandId = createErrandForGiven(createRequest1);
 
     ErrandUpdateRequest updateRequest = ErrandUpdateRequest.builder()
         .title("updatedTitle")
@@ -219,7 +227,7 @@ class ErrandIntegrationTest extends IntegrationTest {
   @DisplayName("의뢰 성공적으로 수정 시, 의뢰자가 아니라서 실패합니다.")
   void updateErrand_fail_because_not_errander() throws Exception {
     // given
-    Long errandId = createErrandForGiven("testTitle", "testContent", PayDivision.HOURLY, 10000);
+    Long errandId = createErrandForGiven(createRequest1);
 
     ErrandUpdateRequest updateRequest = ErrandUpdateRequest.builder()
         .title("updatedTitle")
@@ -244,7 +252,7 @@ class ErrandIntegrationTest extends IntegrationTest {
   @Test
   @DisplayName("의뢰 취소에 성공합니다.")
   void cancelErrand_success() throws Exception {
-    Long errandId = createErrandForGiven("testTitle", "testContent", PayDivision.UNIT, 1000);
+    Long errandId = createErrandForGiven(createRequest1);
 
     ResultActions perform = mvc.perform(
         post("/errands/{id}/cancel", errandId)
@@ -256,7 +264,7 @@ class ErrandIntegrationTest extends IntegrationTest {
   @Test
   @DisplayName("의뢰자가 아니라서 의뢰 취소에 실패합니다.")
   void cancelErrand_fail_because_not_errander() throws Exception {
-    Long errandId = createErrandForGiven("testTitle", "testContent", PayDivision.UNIT, 1000);
+    Long errandId = createErrandForGiven(createRequest1);
     when(authManager.getUsername()).thenReturn(member02.getEmail());
 
     ResultActions perform = mvc.perform(
@@ -269,7 +277,7 @@ class ErrandIntegrationTest extends IntegrationTest {
   @DisplayName("의뢰에 해쉬태그를 추가합니다.")
   void addHashTag_success() throws Exception {
     // given
-    Long errandId = createErrandForGiven("testTitle", "testContent", PayDivision.UNIT, 1000);
+    Long errandId = createErrandForGiven(createRequest1);
     String tag = "알바";
 
     // when
@@ -288,7 +296,7 @@ class ErrandIntegrationTest extends IntegrationTest {
   @DisplayName("의뢰에 해쉬태그를 제거합니다.")
   void deleteHashTag_success() throws Exception {
     // given
-    Long errandId = createErrandForGiven("testTitle", "testContent", PayDivision.UNIT, 1000);
+    Long errandId = createErrandForGiven(createRequest1);
     String tag = "알바";
     requestAddHashtag(errandId, tag);
 
@@ -312,7 +320,7 @@ class ErrandIntegrationTest extends IntegrationTest {
   @DisplayName("의뢰 주소를 수정합니다.")
   void changeErrandAddress_success() throws Exception {
     // given
-    Long errandId = createErrandForGiven("testTitle", "testContent", PayDivision.UNIT, 1000);
+    Long errandId = createErrandForGiven(createRequest1);
     ErrandChangAddressRequest request = new ErrandChangAddressRequest(
         "서울시 강남구", 123.123, 123.123);
 
@@ -338,7 +346,7 @@ class ErrandIntegrationTest extends IntegrationTest {
   @DisplayName("의뢰 좋아요에 성공합니다.")
   void likeErrand_on_success() throws Exception {
     // given
-    Long errandId = createErrandForGiven("testTitle", "testContent", PayDivision.UNIT, 1000);
+    Long errandId = createErrandForGiven(createRequest1);
 
     // when
     ResultActions perform = mvc.perform(
@@ -360,7 +368,7 @@ class ErrandIntegrationTest extends IntegrationTest {
   @DisplayName("의뢰 좋아요 취소에 성공합니다.")
   void likeErrand_cancel_success() throws Exception {
     // given
-    Long errandId = createErrandForGiven("testTitle", "testContent", PayDivision.UNIT, 1000);
+    Long errandId = createErrandForGiven(createRequest1);
     mvc.perform(
         post("/errands/{id}/like", errandId)
     );
@@ -381,17 +389,11 @@ class ErrandIntegrationTest extends IntegrationTest {
     assertThat(likedMembers).doesNotContain(LikedMember.of(errand, member01));
   }
 
-  private ResultActions requestCreateErrand(String title, String content, PayDivision payDivision, Integer pay)
+  private ResultActions requestCreateErrand(ErrandCreateRequest request)
       throws Exception {
-    ErrandCreateRequest createRequest = ErrandCreateRequest.builder()
-        .title(title)
-        .content(content)
-        .payDivision(payDivision)
-        .pay(pay)
-        .build();
 
     MockMultipartFile jsonRequest = new MockMultipartFile("errand", "",
-        "application/json", asJsonString(createRequest).getBytes());
+        "application/json", asJsonString(request).getBytes());
 
     return mvc.perform(
         multipart("/errands")
@@ -406,11 +408,11 @@ class ErrandIntegrationTest extends IntegrationTest {
    * @return 생성된 의뢰의 id
    * @throws Exception
    */
-  private Long createErrandForGiven(String title, String content, PayDivision payDivision, Integer pay)
+  private Long createErrandForGiven(ErrandCreateRequest request)
       throws Exception {
     when(authManager.getUsername()).thenReturn(member01.getEmail());
 
-    MvcResult mvcResult = requestCreateErrand(title, content,payDivision,pay)
+    MvcResult mvcResult = requestCreateErrand(request)
         .andReturn();
 
     return parseNewId(mvcResult);

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/IntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/IntegrationTest.java
@@ -1,6 +1,8 @@
 package com.zerobase.nsbackend.integrationTest;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -19,7 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class IntegrationTest {
   @Autowired
   protected MockMvc mvc;
-  protected ObjectMapper objectMapper = new ObjectMapper();
+  protected ObjectMapper objectMapper = new ObjectMapper()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,false)
+      .registerModule(new JavaTimeModule());
 
   protected String asJsonString(final Object obj) {
     try {


### PR DESCRIPTION
## key Changes ⭐️
- 의뢰 좋아요 기능 추가
   - 의뢰 좋아요
   - 의뢰 조회시 좋아요 여부 반환 (isLiked)
   - 의뢰 조회시 좋아요 갯수 반환 (likeCount)

- 의뢰 생성 시 컬럼 추가
   - 의뢰 해쉬  태그
   - 의뢰 데드라인

- 의뢰 테스트 시, ObjectMapper 로 객체 바인딩

<br/>
참고)
#60 
#71 
#72 
