### PR TITLE
의뢰조회 반환값 수정

### DIFF
--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
@@ -76,14 +76,18 @@ public class ErrandService {
   }
 
   public Errand getErrand(Long id) {
-    return errandRepository.findErrandWithImagesAndHashTagById(id)
-        .orElseThrow(() -> new IllegalArgumentException(ErrorCode.ERRAND_NOT_FOUND.getDescription()));
+    Errand errand = errandRepository.findErrandWithImagesAndHashTagById(id)
+        .orElseThrow(
+            () -> new IllegalArgumentException(ErrorCode.ERRAND_NOT_FOUND.getDescription()));
+    errand.increaseViewCount();
+    return errand;
   }
 
   @Transactional
   public ErrandDto getErrandDto(Long id) {
     Errand errand = getErrand(id);
     Member memberFromAuth = getMemberFromAuth();
+
     boolean isLiked = errand.checkLiked(memberFromAuth);
     return ErrandDto.from(errand, isLiked);
   }

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/ErrandService.java
@@ -12,6 +12,7 @@ import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
 import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
 import com.zerobase.nsbackend.errand.dto.ErrandDto;
 import com.zerobase.nsbackend.errand.dto.ErrandUpdateRequest;
+import com.zerobase.nsbackend.errand.dto.ErranderDto;
 import com.zerobase.nsbackend.global.auth.AuthManager;
 import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
 import com.zerobase.nsbackend.global.fileUpload.StoreFile;
@@ -159,5 +160,14 @@ public class ErrandService {
     errand.like(member);
 
     return errand.checkLiked(member);
+  }
+
+  public ErranderDto findErrander(Long errandId) {
+    Errand errand = getErrand(errandId);
+    Member errander = memberRepository.findById(errand.getErrander().getId())
+        .orElseThrow(() -> new IllegalStateException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
+
+    Integer errandCount = errandRepository.countByErranderId(errander.getId());
+    return ErranderDto.of(errander, errandCount);
   }
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/entity/Errand.java
@@ -127,6 +127,13 @@ public class Errand extends BaseTimeEntity {
     return likedMembers.size();
   }
 
+  /**
+   * 조회 수 1 증가
+   */
+  public void increaseViewCount() {
+    viewCount += 1;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
@@ -15,7 +15,7 @@ public interface ErrandRepository extends JpaRepository<Errand, Long> {
       + " where e.id = :id")
   Optional<Errand> findErrandWithImagesAndHashTagById(@Param("id") Long id);
 
-  @Query("select e "
+  @Query("select distinct e "
       + "from Errand e"
       + " left join fetch e.images "
       + " left join fetch e.hashtags ")

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/repository/ErrandRepository.java
@@ -20,4 +20,7 @@ public interface ErrandRepository extends JpaRepository<Errand, Long> {
       + " left join fetch e.images "
       + " left join fetch e.hashtags ")
   List<Errand> findErrandAllWithImagesAndHashTag();
+
+  @Query("select count(e) from Errand e where e.errander.id = :memberId")
+  Integer countByErranderId(Long memberId);
 }

--- a/src/main/java/com/zerobase/nsbackend/errand/domain/vo/ErrandStatus.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/domain/vo/ErrandStatus.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrandStatus {
-  REQUEST("REQUEST", "요청"),
-  PERFORMING("PERFORMING", "의뢰중"),
+  REQUEST("REQUEST", "의뢰중"),
+  PERFORMING("PERFORMING", "수행중"),
   FINISH("FINISH", "완료"),
   CANCEL("CANCEL", "취소");
 

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
@@ -1,6 +1,7 @@
 package com.zerobase.nsbackend.errand.dto;
 
 import com.zerobase.nsbackend.errand.domain.entity.Errand;
+import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
 import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
 import com.zerobase.nsbackend.global.dto.AddressDto;
 import java.time.LocalDate;
@@ -28,6 +29,7 @@ public class ErrandDto {
   private AddressDto address;
   private boolean isLiked;
   private Integer likedCount;
+  private ErrandStatus status;
   private LocalDateTime createdAt;
 
   public static ErrandDto from(Errand errand) {
@@ -42,6 +44,7 @@ public class ErrandDto {
         .hashtags(errand.getHashtagsAsStringList())
         .address(AddressDto.from(errand.getAddress()))
         .likedCount(errand.getLikedCount())
+        .status(errand.getStatus())
         .createdAt(errand.getCreatedAt())
         .build();
   }

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
@@ -42,6 +42,7 @@ public class ErrandDto {
         .hashtags(errand.getHashtagsAsStringList())
         .address(AddressDto.from(errand.getAddress()))
         .likedCount(errand.getLikedCount())
+        .createdAt(errand.getCreatedAt())
         .build();
   }
 

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErrandDto.java
@@ -30,6 +30,7 @@ public class ErrandDto {
   private boolean isLiked;
   private Integer likedCount;
   private ErrandStatus status;
+  private Integer viewCount;
   private LocalDateTime createdAt;
 
   public static ErrandDto from(Errand errand) {
@@ -45,6 +46,7 @@ public class ErrandDto {
         .address(AddressDto.from(errand.getAddress()))
         .likedCount(errand.getLikedCount())
         .status(errand.getStatus())
+        .viewCount(errand.getViewCount())
         .createdAt(errand.getCreatedAt())
         .build();
   }

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErranderDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErranderDto.java
@@ -1,13 +1,16 @@
 package com.zerobase.nsbackend.errand.dto;
 
 import com.zerobase.nsbackend.member.domain.Member;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErranderDto {
   private Long memberId;
   private String nickname;

--- a/src/main/java/com/zerobase/nsbackend/errand/dto/ErranderDto.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/dto/ErranderDto.java
@@ -1,0 +1,27 @@
+package com.zerobase.nsbackend.errand.dto;
+
+import com.zerobase.nsbackend.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ErranderDto {
+  private Long memberId;
+  private String nickname;
+  private String email;
+  private String profileImage;
+  private Integer errandCount;
+
+  public static ErranderDto of(Member member, Integer errandCount) {
+    return ErranderDto.builder()
+        .memberId(member.getId())
+        .nickname(member.getNickname())
+        .email(member.getEmail())
+        .profileImage(member.getProfileImage())
+        .errandCount(errandCount)
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
+++ b/src/main/java/com/zerobase/nsbackend/errand/web/ErrandController.java
@@ -6,6 +6,7 @@ import com.zerobase.nsbackend.errand.dto.ErrandChangAddressRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandDto;
 import com.zerobase.nsbackend.errand.dto.ErrandUpdateRequest;
+import com.zerobase.nsbackend.errand.dto.ErranderDto;
 import com.zerobase.nsbackend.errand.dto.LikeErrandResponse;
 import java.net.URI;
 import java.util.List;
@@ -88,5 +89,10 @@ public class ErrandController {
   @PostMapping("/{id}/like")
   public ResponseEntity<LikeErrandResponse> likeErrand(@PathVariable Long id) {
     return ResponseEntity.ok(LikeErrandResponse.of(errandService.likeErrand(id)));
+  }
+
+  @GetMapping("/{id}/errander")
+  public ResponseEntity<ErranderDto> readErrander(@PathVariable Long id) {
+    return ResponseEntity.ok(errandService.findErrander(id));
   }
 }

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
@@ -24,6 +24,7 @@ import com.zerobase.nsbackend.errand.dto.ErrandChangAddressRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandDto;
 import com.zerobase.nsbackend.errand.dto.ErrandUpdateRequest;
+import com.zerobase.nsbackend.errand.dto.ErranderDto;
 import com.zerobase.nsbackend.global.auth.AuthManager;
 import com.zerobase.nsbackend.global.exceptionHandle.ErrorCode;
 import com.zerobase.nsbackend.global.vo.Address;
@@ -391,6 +392,34 @@ class ErrandIntegrationTest extends IntegrationTest {
     Set<LikedMember> likedMembers = errand.getLikedMembers();
 
     assertThat(likedMembers).doesNotContain(LikedMember.of(errand, member01));
+  }
+
+  @Test
+  @DisplayName("의뢰자 정보를 조회합니다.")
+  void readErranderSuccess() throws Exception {
+    // given
+    Long errandId = createErrandForGiven(createRequest1);
+
+    // when
+    MvcResult mvcResult = mvc.perform(
+            get("/errands/{id}/errander", errandId)
+        )
+        .andDo(print())
+        .andReturn();
+
+    // then
+    assertThat(mvcResult.getResponse().getStatus()).isEqualTo(HttpStatus.OK.value());
+
+    MockHttpServletResponse mockHttpServletResponse = mvcResult.getResponse();
+    mockHttpServletResponse.setCharacterEncoding("UTF-8");
+    String contentAsString = mockHttpServletResponse.getContentAsString();
+    ErranderDto result = objectMapper.readValue(contentAsString, ErranderDto.class);
+
+    assertThat(result.getMemberId()).isEqualTo(member01.getId());
+    assertThat(result.getNickname()).isEqualTo(member01.getNickname());
+    assertThat(result.getEmail()).isEqualTo(member01.getEmail());
+    assertThat(result.getProfileImage()).isEqualTo(member01.getProfileImage());
+    assertThat(result.getErrandCount()).isEqualTo(1);
   }
 
   private ResultActions requestCreateErrand(ErrandCreateRequest request)

--- a/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
+++ b/src/test/java/com/zerobase/nsbackend/integrationTest/ErrandIntegrationTest.java
@@ -18,6 +18,7 @@ import com.zerobase.nsbackend.errand.domain.entity.ErrandHashtag;
 import com.zerobase.nsbackend.errand.domain.entity.ErrandImage;
 import com.zerobase.nsbackend.errand.domain.entity.LikedMember;
 import com.zerobase.nsbackend.errand.domain.repository.ErrandRepository;
+import com.zerobase.nsbackend.errand.domain.vo.ErrandStatus;
 import com.zerobase.nsbackend.errand.domain.vo.PayDivision;
 import com.zerobase.nsbackend.errand.dto.ErrandChangAddressRequest;
 import com.zerobase.nsbackend.errand.dto.ErrandCreateRequest;
@@ -176,6 +177,9 @@ class ErrandIntegrationTest extends IntegrationTest {
     SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
     assertThat(result.getDeadLine().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
         .isEqualTo(dateFormat.format(createRequest1.getDeadLine()));
+    assertThat(result.getViewCount()).isEqualTo(1);
+    assertThat(result.getCreatedAt()).isNotNull();
+    assertThat(result.getStatus()).isEqualTo(ErrandStatus.REQUEST);
   }
 
   @Test


### PR DESCRIPTION
## key Changes ⭐️
- 의뢰 조회 반환값 추가
   - 조회수
   - 등록일
   - 의뢰상태
-  의뢰자 정보 기능 추가
   - 의뢰자 정보
   - 닉네임
   - 이메일
   - 의뢰수
- fix: 의뢰 전체 조회시, 중복값 제거
   -  fetch join 시, distinct 추가 
   - #79 

<br/>

## To Reviewers 🙏
- 통합테스트, API 테스트 완료하였습니다.

<br/>

- resolve #76
